### PR TITLE
Optional sns topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The dashboard contains one widget per Step Function:
 
 ## Configuration
 
-The `topic` configuration must be configured with the ARN of an SNS Topic.
+The `topic` may be optionally provided as an SNS Topic destination for all alarms.  If you omit the topic, alarms are still created but are not sent to any destination.
 Alarm configuration is _cascading_. This means that configuration properties are automatically propagated from parent to children nodes (unless an override is present at the given node).
 Supported options along with their defaults are shown below.
 
@@ -126,7 +126,7 @@ Supported options along with their defaults are shown below.
 
 custom:
   slicWatch:
-    topic: SNS_TOPIC_ARN
+    topic: SNS_TOPIC_ARN  # This is optional but recommended so you can receive alarms via email, Slack, etc.
 
     alarms:
       enabled: true

--- a/serverless-plugin/alarms-api-gateway.js
+++ b/serverless-plugin/alarms-api-gateway.js
@@ -80,7 +80,7 @@ module.exports = function ApiGatewayAlarms (apiGwAlarmConfig, context) {
       Type: 'AWS::CloudWatch::Alarm',
       Properties: {
         ActionsEnabled: true,
-        AlarmActions: [context.topicArn],
+        AlarmActions: context.alarmActions,
         AlarmName: alarmName,
         AlarmDescription: alarmDescription,
         EvaluationPeriods: evaluationPeriods,

--- a/serverless-plugin/alarms-dynamodb.js
+++ b/serverless-plugin/alarms-dynamodb.js
@@ -77,7 +77,7 @@ module.exports = function DynamoDbAlarms (dynamoDbAlarmConfig, context) {
       Type: 'AWS::CloudWatch::Alarm',
       Properties: {
         ActionsEnabled: true,
-        AlarmActions: [context.topicArn],
+        AlarmActions: context.alarmActions,
         AlarmName: `${metricName}_${identifier}`,
         AlarmDescription: `DynamoDB ${config.Statistic} for ${identifier} breaches ${config.Threshold}`,
         EvaluationPeriods: config.EvaluationPeriods,

--- a/serverless-plugin/alarms-kinesis.js
+++ b/serverless-plugin/alarms-kinesis.js
@@ -62,7 +62,7 @@ module.exports = function KinesisAlarms (kinesisAlarmConfig, context) {
       Type: 'AWS::CloudWatch::Alarm',
       Properties: {
         ActionsEnabled: true,
-        AlarmActions: [context.topicArn],
+        AlarmActions: context.alarmActions,
         AlarmName: `${type}_${streamName}`,
         AlarmDescription: `Kinesis ${config.Statistic} ${metric} for ${streamName} breaches ${threshold} milliseconds`,
         EvaluationPeriods: config.EvaluationPeriods,

--- a/serverless-plugin/alarms-lambda.js
+++ b/serverless-plugin/alarms-lambda.js
@@ -115,7 +115,7 @@ module.exports = function LambdaAlarms (lambdaAlarmConfig, context) {
       Type: 'AWS::CloudWatch::Alarm',
       Properties: {
         ActionsEnabled: true,
-        AlarmActions: [context.topicArn],
+        AlarmActions: context.alarmActions,
         AlarmName: alarmName,
         AlarmDescription: alarmDescription,
         EvaluationPeriods: evaluationPeriods,

--- a/serverless-plugin/alarms-sqs.js
+++ b/serverless-plugin/alarms-sqs.js
@@ -73,7 +73,7 @@ module.exports = function sqsAlarms (sqsAlarmsConfig, context) {
       Type: 'AWS::CloudWatch::Alarm',
       Properties: {
         ActionsEnabled: true,
-        AlarmActions: [context.topicArn],
+        AlarmActions: context.alarmActions,
         AlarmName: alarmName,
         AlarmDescription: alarmDescription,
         EvaluationPeriods: evaluationPeriods,

--- a/serverless-plugin/alarms-step-functions.js
+++ b/serverless-plugin/alarms-step-functions.js
@@ -74,7 +74,7 @@ module.exports = function StatesAlarms (sfAlarmConfig, context) {
       Type: 'AWS::CloudWatch::Alarm',
       Properties: {
         ActionsEnabled: true,
-        AlarmActions: [context.topicArn],
+        AlarmActions: context.alarmActions,
         AlarmName: alarmName,
         AlarmDescription: alarmDescription,
         EvaluationPeriods: evaluationPeriods,

--- a/serverless-plugin/config-schema.js
+++ b/serverless-plugin/config-schema.js
@@ -171,7 +171,7 @@ const slicWatchSchema = {
     dashboard: dashboardSchema,
     topicArn: { type: 'string' }
   },
-  required: ['topicArn']
+  required: []
 }
 
 /**

--- a/serverless-plugin/index.js
+++ b/serverless-plugin/index.js
@@ -44,11 +44,16 @@ class ServerlessPlugin {
       throw new ServerlessError('SLIC Watch configuration is invalid: ' + ajv.errorsText(slicWatchValidate.errors))
     }
 
+    const alarmActions = []
+
+    if (slicWatchConfig.topicArn) {
+      alarmActions.push(slicWatchConfig.topicArn)
+    }
     // Validate and fail fast on config validation errors since this is a warning in Serverless Framework 2.x
     const context = {
       region: this.serverless.service.provider.region,
       stackName: this.providerNaming.getStackName(),
-      topicArn: slicWatchConfig.topicArn
+      alarmActions
     }
 
     const config = _.merge(defaultConfig, slicWatchConfig)

--- a/serverless-plugin/tests/alarm-sqs.test.js
+++ b/serverless-plugin/tests/alarm-sqs.test.js
@@ -7,14 +7,9 @@ const {
   assertCommonAlarmProperties,
   alarmNameToType,
   createTestConfig,
-  createTestCloudFormationTemplate
+  createTestCloudFormationTemplate,
+  testContext
 } = require('./testing-utils')
-
-const context = {
-  topicArn: 'dummy-arn',
-  stackName: 'testStack',
-  region: 'eu-west-1'
-}
 
 test('SQS alarms are created', (t) => {
   const alarmConfig = createTestConfig(
@@ -39,7 +34,7 @@ test('SQS alarms are created', (t) => {
 
   const sqsAlarmConfig = alarmConfig.SQS
 
-  const { createSQSAlarms } = sqsAlarms(sqsAlarmConfig, context)
+  const { createSQSAlarms } = sqsAlarms(sqsAlarmConfig, testContext)
   const cfTemplate = createTestCloudFormationTemplate()
   createSQSAlarms(cfTemplate)
 
@@ -157,7 +152,7 @@ test('SQS alarms are not created when disabled globally', (t) => {
 
   const sqsAlarmConfig = alarmConfig.SQS
 
-  const { createSQSAlarms } = sqsAlarms(sqsAlarmConfig, context)
+  const { createSQSAlarms } = sqsAlarms(sqsAlarmConfig, testContext)
   const cfTemplate = createTestCloudFormationTemplate()
   createSQSAlarms(cfTemplate)
 
@@ -188,7 +183,7 @@ test('SQS alarms are not created when disabled individually', (t) => {
 
   const sqsAlarmConfig = alarmConfig.SQS
 
-  const { createSQSAlarms } = sqsAlarms(sqsAlarmConfig, context)
+  const { createSQSAlarms } = sqsAlarms(sqsAlarmConfig, testContext)
   const cfTemplate = createTestCloudFormationTemplate()
   createSQSAlarms(cfTemplate)
 
@@ -218,7 +213,7 @@ test('SQS AgeOfOldestMessage alarms throws if misconfigured (enabled but no thre
 
   const sqsAlarmConfig = alarmConfig.SQS
 
-  const { createSQSAlarms } = sqsAlarms(sqsAlarmConfig, context)
+  const { createSQSAlarms } = sqsAlarms(sqsAlarmConfig, testContext)
   const cfTemplate = createTestCloudFormationTemplate()
   t.throws(() => createSQSAlarms(cfTemplate), { message: 'SQS AgeOfOldestMessage alarm is enabled but `Threshold` is not specified. Please specify a threshold or disable the alarm.' })
   t.end()

--- a/serverless-plugin/tests/alarms-api-gateway.test.js
+++ b/serverless-plugin/tests/alarms-api-gateway.test.js
@@ -7,14 +7,9 @@ const {
   assertCommonAlarmProperties,
   alarmNameToType,
   createTestConfig,
-  createTestCloudFormationTemplate
+  createTestCloudFormationTemplate,
+  testContext
 } = require('./testing-utils')
-
-const context = {
-  topicArn: 'dummy-arn',
-  stackName: 'testStack',
-  region: 'eu-west-1'
-}
 
 test('API Gateway alarms are created', (t) => {
   const alarmConfig = createTestConfig(
@@ -40,7 +35,7 @@ test('API Gateway alarms are created', (t) => {
 
   const apiGwAlarmConfig = alarmConfig.ApiGateway
 
-  const { createApiGatewayAlarms } = apiGatewayAlarms(apiGwAlarmConfig, context)
+  const { createApiGatewayAlarms } = apiGatewayAlarms(apiGwAlarmConfig, testContext)
   const cfTemplate = createTestCloudFormationTemplate()
   createApiGatewayAlarms(cfTemplate)
 
@@ -139,7 +134,7 @@ test('API Gateway alarms are not created when disabled globally', (t) => {
 
   const apiGwAlarmConfig = alarmConfig.ApiGateway
 
-  const { createApiGatewayAlarms } = apiGatewayAlarms(apiGwAlarmConfig, context)
+  const { createApiGatewayAlarms } = apiGatewayAlarms(apiGwAlarmConfig, testContext)
 
   const cfTemplate = createTestCloudFormationTemplate()
   createApiGatewayAlarms(cfTemplate)
@@ -175,7 +170,7 @@ test('API Gateway alarms are not created when disabled individually', (t) => {
 
   const apiGwAlarmConfig = alarmConfig.ApiGateway
 
-  const { createApiGatewayAlarms } = apiGatewayAlarms(apiGwAlarmConfig, context)
+  const { createApiGatewayAlarms } = apiGatewayAlarms(apiGwAlarmConfig, testContext)
 
   const cfTemplate = createTestCloudFormationTemplate()
   createApiGatewayAlarms(cfTemplate)

--- a/serverless-plugin/tests/alarms-dynamodb.test.js
+++ b/serverless-plugin/tests/alarms-dynamodb.test.js
@@ -11,14 +11,9 @@ const {
   alarmNameToType,
   createTestConfig,
   createTestCloudFormationTemplate,
-  defaultCfTemplate
+  defaultCfTemplate,
+  testContext
 } = require('./testing-utils')
-
-const context = {
-  topicArn: 'dummy-arn',
-  stackName: 'testStack',
-  region: 'eu-west-1'
-}
 
 const alarmConfig = createTestConfig(
   defaultConfig.alarms, {
@@ -46,7 +41,7 @@ const alarmConfig = createTestConfig(
 const dynamoDbAlarmConfig = alarmConfig.DynamoDB
 
 test('DynamoDB alarms are created', (t) => {
-  const { createDynamoDbAlarms } = dynamoDbAlarms(dynamoDbAlarmConfig, context)
+  const { createDynamoDbAlarms } = dynamoDbAlarms(dynamoDbAlarmConfig, testContext)
   const cfTemplate = createTestCloudFormationTemplate()
   createDynamoDbAlarms(cfTemplate)
 
@@ -107,7 +102,7 @@ test('DynamoDB alarms are created', (t) => {
 })
 
 test('DynamoDB alarms are created without GSI', (t) => {
-  const { createDynamoDbAlarms } = dynamoDbAlarms(dynamoDbAlarmConfig, context)
+  const { createDynamoDbAlarms } = dynamoDbAlarms(dynamoDbAlarmConfig, testContext)
   const compiledTemplate = cloneDeep(defaultCfTemplate)
   delete compiledTemplate.Resources.dataTable.Properties.GlobalSecondaryIndexes
   const cfTemplate = createTestCloudFormationTemplate(compiledTemplate)
@@ -126,7 +121,7 @@ test('DynamoDB alarms are not created when disabled', (t) => {
   })
 
   const dynamoDbAlarmConfig = alarmConfig.DynamoDB
-  const { createDynamoDbAlarms } = dynamoDbAlarms(dynamoDbAlarmConfig, context)
+  const { createDynamoDbAlarms } = dynamoDbAlarms(dynamoDbAlarmConfig, testContext)
   const cfTemplate = createTestCloudFormationTemplate()
   createDynamoDbAlarms(cfTemplate)
 

--- a/serverless-plugin/tests/alarms-kinesis.test.js
+++ b/serverless-plugin/tests/alarms-kinesis.test.js
@@ -7,14 +7,9 @@ const {
   assertCommonAlarmProperties,
   alarmNameToType,
   createTestConfig,
-  createTestCloudFormationTemplate
+  createTestCloudFormationTemplate,
+  testContext
 } = require('./testing-utils')
-
-const context = {
-  topicArn: 'dummy-arn',
-  stackName: 'testStack',
-  region: 'eu-west-1'
-}
 
 test('Kinesis data stream alarms are created', (t) => {
   const alarmConfig = createTestConfig(
@@ -34,7 +29,7 @@ test('Kinesis data stream alarms are created', (t) => {
 
   const kinesisAlarmConfig = alarmConfig.Kinesis
 
-  const { createKinesisAlarms } = kinesisAlarms(kinesisAlarmConfig, context)
+  const { createKinesisAlarms } = kinesisAlarms(kinesisAlarmConfig, testContext)
   const cfTemplate = createTestCloudFormationTemplate()
   createKinesisAlarms(cfTemplate)
 
@@ -90,7 +85,7 @@ test('Kinesis data stream alarms are not created when disabled globally', (t) =>
 
   const kinesisAlarmConfig = alarmConfig.Kinesis
 
-  const { createKinesisAlarms } = kinesisAlarms(kinesisAlarmConfig, context)
+  const { createKinesisAlarms } = kinesisAlarms(kinesisAlarmConfig, testContext)
 
   const cfTemplate = createTestCloudFormationTemplate()
   createKinesisAlarms(cfTemplate)

--- a/serverless-plugin/tests/alarms-lambda.test.js
+++ b/serverless-plugin/tests/alarms-lambda.test.js
@@ -8,14 +8,9 @@ const {
   assertCommonAlarmProperties,
   alarmNameToType,
   createTestConfig,
-  createTestCloudFormationTemplate
+  createTestCloudFormationTemplate,
+  testContext
 } = require('./testing-utils')
-
-const context = {
-  topicArn: 'dummy-arn',
-  stackName: 'testStack',
-  region: 'eu-west-1'
-}
 
 test('AWS Lambda alarms are created', (t) => {
   const alarmConfig = createTestConfig(defaultConfig.alarms, {
@@ -43,7 +38,7 @@ test('AWS Lambda alarms are created', (t) => {
   })
 
   const lambdaAlarmConfig = alarmConfig.Lambda
-  const { createLambdaAlarms } = lambdaAlarms(lambdaAlarmConfig, context)
+  const { createLambdaAlarms } = lambdaAlarms(lambdaAlarmConfig, testContext)
   const cfTemplate = createTestCloudFormationTemplate()
   createLambdaAlarms(cfTemplate)
 
@@ -154,7 +149,7 @@ test('Invocation alarms are created if configured', (t) => {
   })
   const lambdaAlarmConfig = alarmConfig.Lambda
 
-  const { createLambdaAlarms } = lambdaAlarms(lambdaAlarmConfig, context)
+  const { createLambdaAlarms } = lambdaAlarms(lambdaAlarmConfig, testContext)
   const cfTemplate = createTestCloudFormationTemplate()
   createLambdaAlarms(cfTemplate)
 
@@ -202,7 +197,7 @@ test('Invocation alarms throws if misconfigured (enabled but no threshold set)',
   })
   const lambdaAlarmConfig = alarmConfig.Lambda
 
-  const { createLambdaAlarms } = lambdaAlarms(lambdaAlarmConfig, context)
+  const { createLambdaAlarms } = lambdaAlarms(lambdaAlarmConfig, testContext)
   const cfTemplate = createTestCloudFormationTemplate()
   t.throws(() => createLambdaAlarms(cfTemplate), { message: 'Lambda invocation alarm is enabled but `Threshold` is not specified. Please specify a threshold or disable the alarm.' })
   t.end()
@@ -258,7 +253,7 @@ test('Invocation alarms throws if misconfigured (enabled but no threshold set)',
       }
     )
 
-    const { createLambdaAlarms } = lambdaAlarms(lambdaAlarmConfig, context)
+    const { createLambdaAlarms } = lambdaAlarms(lambdaAlarmConfig, testContext)
     createLambdaAlarms(cfTemplate)
     const alarmResources = cfTemplate.getResourcesByType(
       'AWS::CloudWatch::Alarm'
@@ -292,7 +287,7 @@ test('Lambda alarms are not created when disabled globally', (t) => {
   })
 
   const lambdaAlarmConfig = alarmConfig.Lambda
-  const { createLambdaAlarms } = lambdaAlarms(lambdaAlarmConfig, context)
+  const { createLambdaAlarms } = lambdaAlarms(lambdaAlarmConfig, testContext)
   const cfTemplate = createTestCloudFormationTemplate()
   createLambdaAlarms(cfTemplate)
 
@@ -331,7 +326,7 @@ test('Lambda alarms are not created when disabled individually', (t) => {
   })
 
   const lambdaAlarmConfig = alarmConfig.Lambda
-  const { createLambdaAlarms } = lambdaAlarms(lambdaAlarmConfig, context)
+  const { createLambdaAlarms } = lambdaAlarms(lambdaAlarmConfig, testContext)
   const cfTemplate = createTestCloudFormationTemplate()
   createLambdaAlarms(cfTemplate)
 

--- a/serverless-plugin/tests/alarms-step-functions.test.js
+++ b/serverless-plugin/tests/alarms-step-functions.test.js
@@ -7,14 +7,9 @@ const {
   assertCommonAlarmProperties,
   alarmNameToType,
   createTestConfig,
-  createTestCloudFormationTemplate
+  createTestCloudFormationTemplate,
+  testContext
 } = require('./testing-utils')
-
-const context = {
-  topicArn: 'dummy-arn',
-  stackName: 'testStack',
-  region: 'eu-west-1'
-}
 
 test('Step Function alarms are created', (t) => {
   const alarmConfig = createTestConfig(
@@ -41,7 +36,7 @@ test('Step Function alarms are created', (t) => {
 
   const sfAlarmConfig = alarmConfig.States
 
-  const { createStatesAlarms } = stepFunctionsAlarms(sfAlarmConfig, context)
+  const { createStatesAlarms } = stepFunctionsAlarms(sfAlarmConfig, testContext)
   const cfTemplate = createTestCloudFormationTemplate()
   createStatesAlarms(cfTemplate)
 
@@ -111,7 +106,7 @@ test('Step function alarms are not created when disabled globally', (t) => {
 
   const sfAlarmConfig = alarmConfig.States
 
-  const { createStatesAlarms } = stepFunctionsAlarms(sfAlarmConfig, context)
+  const { createStatesAlarms } = stepFunctionsAlarms(sfAlarmConfig, testContext)
   const cfTemplate = createTestCloudFormationTemplate()
   createStatesAlarms(cfTemplate)
 
@@ -146,7 +141,7 @@ test('Step function alarms are not created when disabled individually', (t) => {
 
   const sfAlarmConfig = alarmConfig.States
 
-  const { createStatesAlarms } = stepFunctionsAlarms(sfAlarmConfig, context)
+  const { createStatesAlarms } = stepFunctionsAlarms(sfAlarmConfig, testContext)
   const cfTemplate = createTestCloudFormationTemplate()
   createStatesAlarms(cfTemplate)
 

--- a/serverless-plugin/tests/config-schema.test.js
+++ b/serverless-plugin/tests/config-schema.test.js
@@ -24,3 +24,21 @@ test('Default config conforms to the config schema', (t) => {
 
   t.end()
 })
+
+test('Default config conforms to the config schema without topicArn', (t) => {
+  const slicWatchConfig = {
+    ...defaultConfig
+  }
+
+  const ajv = new Ajv()
+  const slicWatchValidate = ajv.compile(slicWatchSchema)
+  const slicWatchValid = slicWatchValidate(slicWatchConfig)
+  t.ok(slicWatchValid, slicWatchValidate.errors)
+
+  const pluginValidate = ajv.compile(pluginConfigSchema)
+  const testConfig = { slicWatch: slicWatchConfig }
+  const pluginValid = pluginValidate(testConfig)
+  t.ok(pluginValid, pluginValidate.errors)
+
+  t.end()
+})

--- a/serverless-plugin/tests/index.test.js
+++ b/serverless-plugin/tests/index.test.js
@@ -6,7 +6,6 @@ const yaml = require('js-yaml')
 
 const proxyrequire = require('proxyquire')
 const { test } = require('tap')
-const ServerlessError = require('serverless/lib/serverless-error')
 
 const slsYamlPath = path.resolve(
   __dirname,
@@ -120,7 +119,7 @@ test('Plugin execution fails with no slicWatch config', (t) => {
   t.end()
 })
 
-test('Plugin execution fails if no SNS Topic is provided', (t) => {
+test('Plugin execution succeeds if no SNS Topic is provided', (t) => {
   const serviceYmlWithoutTopic = { ...slsYaml, custom: { slicWatch: {} } }
   const plugin = new ServerlessPlugin(
     {
@@ -129,6 +128,6 @@ test('Plugin execution fails if no SNS Topic is provided', (t) => {
     },
     {}
   )
-  t.throws(() => plugin.finalizeHook(), new ServerlessError('SLIC Watch configuration is invalid: data should have required property \'topicArn\''))
+  plugin.finalizeHook()
   t.end()
 })

--- a/serverless-plugin/tests/testing-utils.js
+++ b/serverless-plugin/tests/testing-utils.js
@@ -5,6 +5,12 @@ const { cascade } = require('../cascading-config')
 const CloudFormationTemplate = require('../cf-template')
 const defaultCfTemplate = require('./resources/cloudformation-template-stack.json')
 
+const testContext = {
+  alarmActions: ['dummy-arn'],
+  stackName: 'testStack',
+  region: 'eu-west-1'
+}
+
 const slsMock = {
   cli: {
     log: () => {}
@@ -14,6 +20,7 @@ const slsMock = {
 module.exports = {
   slsMock,
   defaultCfTemplate,
+  testContext,
   assertCommonAlarmProperties,
   alarmNameToType,
   createTestConfig,


### PR DESCRIPTION
Making `topicArn` mandatory wasn't necessary. Alarms don't require it, so why should we? It is friction for people who just want to try SLIC Watch out.
This change makes `topicArn` optional, allowing users to include or exclude it. They can still view alarms via the AWS Console, etc.