### PR TITLE
Succeed if plugin config is not provided

### DIFF
--- a/serverless-plugin/index.js
+++ b/serverless-plugin/index.js
@@ -36,7 +36,7 @@ class ServerlessPlugin {
    * Modify the CloudFormation template before the package is finalized
    */
   finalizeHook () {
-    const slicWatchConfig = (this.serverless.service.custom || {}).slicWatch
+    const slicWatchConfig = (this.serverless.service.custom || {}).slicWatch || {}
 
     const ajv = new Ajv()
     const slicWatchValidate = ajv.compile(slicWatchSchema)

--- a/serverless-plugin/tests/index.test.js
+++ b/serverless-plugin/tests/index.test.js
@@ -96,7 +96,7 @@ test('finalizeHook adds dashboard and alarms', (t) => {
   t.end()
 })
 
-test('Plugin fails to run load with no custom section', (t) => {
+test('Plugin succeeds with no custom section', (t) => {
   const plugin = new ServerlessPlugin({
     ...mockServerless,
     service: {
@@ -104,7 +104,7 @@ test('Plugin fails to run load with no custom section', (t) => {
       custom: undefined
     }
   })
-  t.throws(() => plugin.finalizeHook())
+  plugin.finalizeHook()
   t.end()
 })
 
@@ -126,7 +126,7 @@ test('Plugin registers the configuration schema', (t) => {
   t.end()
 })
 
-test('Plugin execution fails with no slicWatch config', (t) => {
+test('Plugin execution succeeds with no slicWatch config', (t) => {
   const plugin = new ServerlessPlugin({
     ...mockServerless,
     service: {
@@ -134,10 +134,7 @@ test('Plugin execution fails with no slicWatch config', (t) => {
       custom: {}
     }
   })
-  t.throws(
-    () =>
-      plugin.finalizeHook()
-  )
+  plugin.finalizeHook()
   t.end()
 })
 


### PR DESCRIPTION
- Fixes #63
- Reflects documented behaviour, that plugin config is optional

## Description
Treat missing config as empty config

## Motivation and Context
The README says that [plugin config is optional](https://github.com/fourTheorem/slic-watch/blob/main/README.md#getting-started). This conflicted with the behaviour, where `sls package|deploy` would fail with `SLIC Watch configuration is invalid: data should be object`

## How Has This Been Tested?
- Unit test added
 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] All new and existing tests passed.
