### PR TITLE
fix(serverless-test-project): use CloudFormation for EventBridge event

### DIFF
--- a/serverless-test-project/serverless-v2.yml
+++ b/serverless-test-project/serverless-v2.yml
@@ -32,6 +32,8 @@ provider:
   region: eu-west-1
   stage: dev
   endpointType: REGIONAL
+  eventBridge:
+    useCloudFormation: true
 
 functions:
   hello:


### PR DESCRIPTION
Resolves Serverless Framework v2 error in test (causing build failure):
```
  Configuring RetryPolicy is not supported for EventBridge integration backed by
  Custom Resources. Please use "provider.eventBridge.useCloudFormation" setting
  to use native CloudFormation support for EventBridge.
```

## Description
Ensure that CloudFormation is used to generate EventBridge resources instead of custom resources

## Motivation and Context
Fixes https://github.com/fourTheorem/slic-watch/runs/7382744597?check_suite_focus=true

## How Has This Been Tested?
Tested with serverless@2 and `sls package` in `serverless-test-project`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
