### PR TITLE
fix(core): exclude Lambda metrics if TG target is not Lambda

### DIFF
--- a/core/dashboard.js
+++ b/core/dashboard.js
@@ -602,14 +602,16 @@ module.exports = function dashboard (dashboardConfig, functionDashboardConfigs, 
    */
   function createTargetGroupWidgets (targetGroupResources, cfTemplate) {
     const targetGroupWidgets = []
-    for (const tgLogicalId of Object.keys(targetGroupResources)) {
+    for (const [tgLogicalId, targetGroupResource] of Object.entries(targetGroupResources)) {
       const loadBalancerLogicalIds = findLoadBalancersForTargetGroup(tgLogicalId, cfTemplate)
       for (const loadBalancerLogicalId of loadBalancerLogicalIds) {
         const targetGroupFullName = resolveTargetGroupFullNameForSub(tgLogicalId)
         const loadBalancerFullName = `\${${loadBalancerLogicalId}.LoadBalancerFullName}`
         const widgetMetrics = []
         for (const [metric, metricConfig] of Object.entries(getConfiguredMetrics(albTargetDashConfig))) {
-          if (metricConfig.enabled) {
+          if (metricConfig.enabled &&
+            (targetGroupResource.Properties.TargetType === 'lambda' || !['LambdaUserError', 'LambdaInternalError'].includes(metric))
+          ) {
             for (const stat of metricConfig.Statistic) {
               widgetMetrics.push({
                 namespace: 'AWS/ApplicationELB',


### PR DESCRIPTION
LambdaUserError and LambdaInternalError metrics were being included for ALB TargetGroup resources, even if the target type was not Lambda. This was previously fixed for alarms, but not dashboard.

## How Has This Been Tested?
Unit test added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
