### PR TITLE
Cascade using simple objects

### DIFF
--- a/core/alarms/alarms.ts
+++ b/core/alarms/alarms.ts
@@ -34,7 +34,7 @@ export default function addAlarms (alarmProperties: SlicWatchAlarmsConfig, funct
     ApplicationELB: albConfig,
     ApplicationELBTarget: albTargetConfig,
     AppSync: appSyncConfig
-  } = cascade(alarmProperties)
+  } = cascade(alarmProperties) as SlicWatchAlarmsConfig
 
   const cascadedFunctionAlarmProperties = applyAlarmConfig(lambdaConfig, functionAlarmProperties)
 

--- a/core/dashboards/dashboard.ts
+++ b/core/dashboards/dashboard.ts
@@ -103,7 +103,7 @@ export default function addDashboard (dashboardConfig: SlicWatchDashboardConfig,
       ApplicationELBTarget: albTargetDashConfig,
       AppSync: appSyncDashConfig
     }
-  } = cascade(dashboardConfig)
+  } = cascade(dashboardConfig) as SlicWatchDashboardConfig
 
   /**
    * Adds a dashboard to the specified CloudFormation template
@@ -315,7 +315,7 @@ export default function addDashboard (dashboardConfig: SlicWatchDashboardConfig,
    * These config objects mix cascaded config literals (like `alarmPeriod: 300`) and metric
    * configurations (like `Errors: { Statistic: ['Sum'] }`) so here we extract the latter.
    *
-   *  The config object for a specific service within the dashboard
+   * @param serviceDashConfig t The config object for a specific service within the dashboard
    * @returns {Iterable} An iterable over the alarm-config Object entries
    */
   function getConfiguredMetrics (serviceDashConfig): ServiceDashConfig {

--- a/core/inputs/cascading-config.ts
+++ b/core/inputs/cascading-config.ts
@@ -11,21 +11,13 @@ import type { SnsAlarmsConfig } from '../alarms/sns'
 import type { SqsAlarmsConfig } from '../alarms/sqs'
 import type { SfAlarmsConfig } from '../alarms/step-functions'
 import type {
-  DashboardBodyProperties, LambdaDashboardBodyProperties, ApiGwDashboardBodyProperties, SfDashboardBodyProperties, DynamoDbDashboardBodyProperties,
+  LambdaDashboardBodyProperties, ApiGwDashboardBodyProperties, SfDashboardBodyProperties, DynamoDbDashboardBodyProperties,
   KinesisDashboardBodyProperties, SqsDashboardBodyProperties, EcsDashboardBodyProperties, SnsDashboardBodyProperties, RuleDashboardBodyProperties,
   AlbDashboardBodyProperties, AlbTargetDashboardBodyProperties, AppSyncDashboardBodyProperties
 } from '../dashboards/default-config-dashboard'
 import type { LambdaFunctionAlarmsConfig } from '../alarms/lambda'
-import type { DefaultAlarmsProperties } from '../alarms/default-config-alarms'
 
 const MAX_DEPTH = 10
-
-type ConfigNode = SlicWatchDashboardConfig | SlicWatchAlarmsConfig
-
-interface ParentNode {
-  DashboardBodyProperties?: DashboardBodyProperties
-  AlarmProperties?: DefaultAlarmsProperties
-}
 
 interface TimeRange {
   start: string
@@ -85,9 +77,7 @@ export interface SlicWatchAlarmsConfig {
  * node hierarchical configuration
  * parentNode The configuration from the parent node to be applied to the current node where no conflict occurs
  */
-export function cascade (node: SlicWatchAlarmsConfig, parentNode?: ParentNode, depth?: number): SlicWatchAlarmsConfig
-export function cascade (node: SlicWatchDashboardConfig, parentNode?: ParentNode, depth?: number): SlicWatchDashboardConfig
-export function cascade (node: ConfigNode, parentNode?: ParentNode, depth = 0): SlicWatchAlarmsConfig | SlicWatchDashboardConfig {
+export function cascade (node: object, parentNode?: object, depth = 0): object {
   if (depth > 10) {
     throw new Error(`Maximum configuration depth of ${MAX_DEPTH} reached`)
   }
@@ -101,12 +91,12 @@ export function cascade (node: ConfigNode, parentNode?: ParentNode, depth = 0): 
     }
   }
 
-  const compiledChildren = {}
+  const compiledChildren: Record<string, object> = {}
   for (const [key, value] of Object.entries(childNodes)) {
     compiledChildren[key] = cascade(value, compiledNode, depth + 1)
   }
   return {
     ...compiledNode,
     ...compiledChildren
-  } as SlicWatchDashboardConfig | SlicWatchAlarmsConfig
+  }
 }


### PR DESCRIPTION
This is a suggested approach for cascading in TypeScript.
The `cascade` function is simply designed to copy object properties down to all nested properties in a JavaScript object.
There is nothing within this function that is specific to dashboard or alarm configuration - it could be used for configuration in many different projects.
This approach therefore suggests to use simple object/`Record` types and Type Assertions (` as `). I didn't validate that it works really, except for checking for TS errors in the fields involved.