### PR TITLE
Calculate throttling percentage correctly

### DIFF
--- a/core/alarms-lambda.js
+++ b/core/alarms-lambda.js
@@ -190,7 +190,7 @@ module.exports = function LambdaAlarms (functionAlarmConfigs, context) {
     const metrics = [
       {
         Id: 'throttles_pc',
-        Expression: '(throttles / throttles + invocations) * 100',
+        Expression: '(throttles / (throttles + invocations)) * 100',
         Label: '% Throttles',
         ReturnData: true
       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix math expression that calculates the ratio of throttles.

## Description
Just adding brackets to fix the order of math evaluation.

## Motivation and Context
Fixes the issue reported here - https://github.com/fourTheorem/slic-watch/issues/108

## How Has This Been Tested?

1. `npm run test`
2. Checking this expression manually in AWS.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
