### PR TITLE
fix(core): fix alarm logical IDs for API GWs with object names

### DIFF
--- a/core/alarms-api-gateway.js
+++ b/core/alarms-api-gateway.js
@@ -97,7 +97,7 @@ module.exports = function ApiGatewayAlarms (apiGwAlarmConfig, context) {
     const apiNameForSub = resolveRestApiNameForSub(apiResource, apiResourceName)
     const threshold = config.Threshold
     return {
-      resourceName: makeResourceName('Api', apiName, 'Availability'),
+      resourceName: makeResourceName('Api', apiResourceName, 'Availability'),
       resource: createApiAlarm(
         { 'Fn::Sub': `APIGW_5XXError_${apiNameForSub}` },
         { 'Fn::Sub': `API Gateway 5XXError ${getStatisticName(config)} for ${apiNameForSub} breaches ${threshold}` },
@@ -119,7 +119,7 @@ module.exports = function ApiGatewayAlarms (apiGwAlarmConfig, context) {
     const apiNameForSub = resolveRestApiNameForSub(apiResource, apiResourceName)
     const threshold = config.Threshold
     return {
-      resourceName: makeResourceName('Api', apiName, '4XXError'),
+      resourceName: makeResourceName('Api', apiResourceName, '4XXError'),
       resource: createApiAlarm(
         { 'Fn::Sub': `APIGW_4XXError_${apiNameForSub}` },
         { 'Fn::Sub': `API Gateway 4XXError ${getStatisticName(config)} for ${apiNameForSub} breaches ${threshold}` },
@@ -141,7 +141,7 @@ module.exports = function ApiGatewayAlarms (apiGwAlarmConfig, context) {
     const apiNameForSub = resolveRestApiNameForSub(apiResource, apiResourceName)
     const threshold = config.Threshold
     return {
-      resourceName: makeResourceName('Api', apiName, 'Latency'),
+      resourceName: makeResourceName('Api', apiResourceName, 'Latency'),
       resource: createApiAlarm(
         { 'Fn::Sub': `APIGW_Latency_${apiNameForSub}` },
         { 'Fn::Sub': `API Gateway Latency ${getStatisticName(config)} for ${apiNameForSub} breaches ${threshold}` },

--- a/core/tests/alarms-api-gateway.test.js
+++ b/core/tests/alarms-api-gateway.test.js
@@ -36,112 +36,137 @@ test('API Gateway alarms are created', (t) => {
   const apiGwAlarmConfig = alarmConfig.ApiGateway
 
   const { createApiGatewayAlarms } = apiGatewayAlarms(apiGwAlarmConfig, testContext)
-  const cfTemplate = createTestCloudFormationTemplate()
-  createApiGatewayAlarms(cfTemplate)
 
-  const alarmResources = cfTemplate.getResourcesByType('AWS::CloudWatch::Alarm')
+  t.test('with full template', (t) => {
+    const cfTemplate = createTestCloudFormationTemplate()
+    createApiGatewayAlarms(cfTemplate)
 
-  const alarmsByType = {}
-  t.equal(Object.keys(alarmResources).length, 3)
-  for (const alarmResource of Object.values(alarmResources)) {
-    const al = alarmResource.Properties
-    assertCommonAlarmProperties(t, al)
-    const alarmType = alarmNameToType(al.AlarmName)
-    alarmsByType[alarmType] = alarmsByType[alarmType] || new Set()
-    alarmsByType[alarmType].add(al)
-  }
+    const alarmResources = cfTemplate.getResourcesByType('AWS::CloudWatch::Alarm')
 
-  t.same(Object.keys(alarmsByType).sort(), [
-    'APIGW_4XXError',
-    'APIGW_5XXError',
-    'APIGW_Latency'
-  ])
+    const alarmsByType = {}
+    t.equal(Object.keys(alarmResources).length, 3)
+    for (const alarmResource of Object.values(alarmResources)) {
+      const al = alarmResource.Properties
+      assertCommonAlarmProperties(t, al)
+      const alarmType = alarmNameToType(al.AlarmName)
+      alarmsByType[alarmType] = alarmsByType[alarmType] || new Set()
+      alarmsByType[alarmType].add(al)
+    }
 
-  t.equal(alarmsByType.APIGW_5XXError.size, 1)
-  for (const al of alarmsByType.APIGW_5XXError) {
-    t.equal(al.MetricName, '5XXError')
-    t.equal(al.Statistic, 'Average')
-    t.equal(al.Threshold, apiGwAlarmConfig['5XXError'].Threshold)
-    t.equal(al.EvaluationPeriods, 2)
-    t.equal(al.TreatMissingData, 'breaching')
-    t.equal(al.ComparisonOperator, 'GreaterThanOrEqualToThreshold')
-    t.equal(al.Namespace, 'AWS/ApiGateway')
-    t.equal(al.Period, 120)
-    t.same(al.Dimensions, [
-      {
-        Name: 'ApiName',
-        Value: 'dev-serverless-test-project'
-      }
+    t.same(Object.keys(alarmsByType).sort(), [
+      'APIGW_4XXError',
+      'APIGW_5XXError',
+      'APIGW_Latency'
     ])
-  }
 
-  for (const al of alarmsByType.APIGW_4XXError) {
-    t.equal(al.MetricName, '4XXError')
-    t.equal(al.Statistic, 'Average')
-    t.equal(al.Threshold, apiGwAlarmConfig['4XXError'].Threshold)
-    t.equal(al.EvaluationPeriods, 2)
-    t.equal(al.TreatMissingData, 'breaching')
-    t.equal(al.ComparisonOperator, 'GreaterThanOrEqualToThreshold')
-    t.equal(al.Namespace, 'AWS/ApiGateway')
-    t.equal(al.Period, 120)
-    t.same(al.Dimensions, [
+    t.equal(alarmsByType.APIGW_5XXError.size, 1)
+    for (const al of alarmsByType.APIGW_5XXError) {
+      t.equal(al.MetricName, '5XXError')
+      t.equal(al.Statistic, 'Average')
+      t.equal(al.Threshold, apiGwAlarmConfig['5XXError'].Threshold)
+      t.equal(al.EvaluationPeriods, 2)
+      t.equal(al.TreatMissingData, 'breaching')
+      t.equal(al.ComparisonOperator, 'GreaterThanOrEqualToThreshold')
+      t.equal(al.Namespace, 'AWS/ApiGateway')
+      t.equal(al.Period, 120)
+      t.same(al.Dimensions, [
+        {
+          Name: 'ApiName',
+          Value: 'dev-serverless-test-project'
+        }
+      ])
+    }
+
+    for (const al of alarmsByType.APIGW_4XXError) {
+      t.equal(al.MetricName, '4XXError')
+      t.equal(al.Statistic, 'Average')
+      t.equal(al.Threshold, apiGwAlarmConfig['4XXError'].Threshold)
+      t.equal(al.EvaluationPeriods, 2)
+      t.equal(al.TreatMissingData, 'breaching')
+      t.equal(al.ComparisonOperator, 'GreaterThanOrEqualToThreshold')
+      t.equal(al.Namespace, 'AWS/ApiGateway')
+      t.equal(al.Period, 120)
+      t.same(al.Dimensions, [
+        {
+          Name: 'ApiName',
+          Value: 'dev-serverless-test-project'
+        }
+      ])
+    }
+
+    for (const al of alarmsByType.APIGW_Latency) {
+      t.equal(al.MetricName, 'Latency')
+      t.equal(al.ExtendedStatistic, 'p99')
+      t.equal(al.Threshold, apiGwAlarmConfig.Latency.Threshold)
+      t.equal(al.EvaluationPeriods, 2)
+      t.equal(al.TreatMissingData, 'breaching')
+      t.equal(al.ComparisonOperator, 'GreaterThanOrEqualToThreshold')
+      t.equal(al.Namespace, 'AWS/ApiGateway')
+      t.equal(al.Period, 120)
+      t.same(al.Dimensions, [
+        {
+          Name: 'ApiName',
+          Value: 'dev-serverless-test-project'
+        }
+      ])
+    }
+
+    t.end()
+  })
+
+  test('API Gateway alarms are not created when disabled globally', (t) => {
+    const alarmConfig = createTestConfig(
+      defaultConfig.alarms,
       {
-        Name: 'ApiName',
-        Value: 'dev-serverless-test-project'
-      }
-    ])
-  }
-
-  for (const al of alarmsByType.APIGW_Latency) {
-    t.equal(al.MetricName, 'Latency')
-    t.equal(al.ExtendedStatistic, 'p99')
-    t.equal(al.Threshold, apiGwAlarmConfig.Latency.Threshold)
-    t.equal(al.EvaluationPeriods, 2)
-    t.equal(al.TreatMissingData, 'breaching')
-    t.equal(al.ComparisonOperator, 'GreaterThanOrEqualToThreshold')
-    t.equal(al.Namespace, 'AWS/ApiGateway')
-    t.equal(al.Period, 120)
-    t.same(al.Dimensions, [
-      {
-        Name: 'ApiName',
-        Value: 'dev-serverless-test-project'
-      }
-    ])
-  }
-
-  t.end()
-})
-
-test('API Gateway alarms are not created when disabled globally', (t) => {
-  const alarmConfig = createTestConfig(
-    defaultConfig.alarms,
-    {
-      ApiGateway: {
-        enabled: false, // disabled globally
-        Period: 60,
-        '5XXError': {
-          Threshold: 0.0
-        },
-        '4XXError': {
-          Threshold: 0.05
-        },
-        Latency: {
-          Threshold: 5000
+        ApiGateway: {
+          enabled: false, // disabled globally
+          Period: 60,
+          '5XXError': {
+            Threshold: 0.0
+          },
+          '4XXError': {
+            Threshold: 0.05
+          },
+          Latency: {
+            Threshold: 5000
+          }
         }
       }
-    }
-  )
+    )
 
-  const apiGwAlarmConfig = alarmConfig.ApiGateway
+    const apiGwAlarmConfig = alarmConfig.ApiGateway
 
-  const { createApiGatewayAlarms } = apiGatewayAlarms(apiGwAlarmConfig, testContext)
+    const { createApiGatewayAlarms } = apiGatewayAlarms(apiGwAlarmConfig, testContext)
 
-  const cfTemplate = createTestCloudFormationTemplate()
-  createApiGatewayAlarms(cfTemplate)
+    const cfTemplate = createTestCloudFormationTemplate()
+    createApiGatewayAlarms(cfTemplate)
 
-  const alarmResources = cfTemplate.getResourcesByType('AWS::CloudWatch::Alarm')
+    const alarmResources = cfTemplate.getResourcesByType('AWS::CloudWatch::Alarm')
 
-  t.same({}, alarmResources)
+    t.same({}, alarmResources)
+    t.end()
+  })
+
+  t.test('alarm logical IDs are correct when an intrinsic function is used in the API Gateway name', (t) => {
+    const cfTemplate = createTestCloudFormationTemplate({
+      Resources: {
+        myApi: {
+          Type: 'AWS::ApiGateway::RestApi',
+          Properties: {
+            Name: { Ref: 'AWS::StackName' }
+          }
+        }
+      }
+    })
+    createApiGatewayAlarms(cfTemplate)
+    const alarmResources = cfTemplate.getResourcesByType('AWS::CloudWatch::Alarm')
+    t.same(Object.keys(alarmResources).sort(), [
+      'slicWatchApi4XXErrorAlarmMyApi',
+      'slicWatchApiAvailabilityAlarmMyApi',
+      'slicWatchApiLatencyAlarmMyApi'
+    ])
+    t.end()
+  })
   t.end()
 })
 


### PR DESCRIPTION
- Ensure correct logical IDs even when intrinsic functions used in API Gateway name

## Description
Prevents "ObjectObject" in alarm names, relying on the logical ID of the API Gateway to generate the logical ID of the associated alarms

## Motivation and Context
Intrinsic functions in API Gateway names were causing `Object` to appear in alarm logical IDs

## How Has This Been Tested?
- Tested with a stack that caused the problem in the first place
- Unit tests added
- 
## Screenshots (if appropriate):

## Types of changes

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I have read the **CONTRIBUTING.md** document.
- [ X] I have added tests to cover my changes.
- [ X] All new and existing tests passed.
