### PR TITLE
feat: support OK actions for alarms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -260,3 +260,5 @@ lerna-debug*
 
 samconfig.toml
 packaged.yaml
+.tgz
+*.tar.gz

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ so you can receive alarm notifications via email, Slack, etc.
 ```yaml
 custom:
   slicWatch:
-    topicArn: {'Fn::Ref': myTopic}
+    alarmActionsConfig: {
+      alarmActions: [{'Fn::Ref': myTopic}]
+    }
 ```
 See the [Configuration](#configuration) section below for more detailed instructions on fine tuning SLIC Watch to your needs.
 
@@ -125,7 +127,9 @@ so you can receive alarm notifications via email, Slack, etc.
 Metadata:
   slicWatch:
     enabled: true
-    topicArn: !Ref MonitoringTopic
+    alarmActionsConfig:
+      alarmActions:
+        - !Ref MonitoringTopic
 ```
 See the [Configuration](#configuration) section below for more detailed instructions on fine tuning SLIC Watch to your needs.
 
@@ -166,7 +170,11 @@ this.addTransform("SlicWatch-v3");
 this.templateOptions.metadata = {
   slicWatch: {
     enabled: true,
-    topicArn: "arn:aws:sns:eu-west-1:xxxxxxx:topic",
+    alarmActionsConfig: {
+      alarmActions: ["arn:aws:sns:eu-west-1:xxxxxxx:topic"],
+      okActions: ["arn:aws:sns:eu-west-1:xxxxxxx:topic"],
+      actionsEnabled: true
+    }
   }
 }
 ```
@@ -358,7 +366,17 @@ this.templateOptions.metadata = {
 }
 ```
 
-- The `topicArn` may be optionally provided as an SNS Topic destination for all alarms.  If you omit the topic, alarms are still created but are not sent to any destination.
+- The `alarmActionsConfig` may be optionally added to specifc one or more SNS Topic destinations for all alarm status changes to `ALARM` and `OK`.  If you omit destination topics, alarms are still created but are not sent to any destination. For example:
+```yaml
+slicWatch:
+  alarmActionsConfig:
+    alarmActions: # Default to no actions
+      - arn:aws:sns:eu-west-1:123456789012
+    okActions: # Defaults to no actions
+      - arn:aws:sns:eu-west-1:123456789012
+    actionsEnabled: 
+      - true # Defaults to true
+```
 - Alarms or dashboards can be disabled at any level in the configuration by adding `enabled: false`. You can even disable all plugin functionality by specifying `enabled: false` at the top-level plugin configuration.
 
 A complete set of supported options along with their defaults are shown in [default-config.js](./core/default-config.js)

--- a/cdk-test-project/source/ecs-stack.ts
+++ b/cdk-test-project/source/ecs-stack.ts
@@ -10,7 +10,7 @@ export class CdkECSStack extends cdk.Stack {
     this.templateOptions.metadata = {
       slicWatch: {
         enabled: true,
-        // "topicArn": "arn:aws:xxxxxx:mytopic",
+        // alarmActionsConfig: { alarmActions: ["arn:aws:xxxxxx:mytopic"] },
         alarms: {
           Lambda: {
             Invocations: {

--- a/cdk-test-project/source/general-stack.ts
+++ b/cdk-test-project/source/general-stack.ts
@@ -40,7 +40,9 @@ export class CdkTestGeneralStack extends cdk.Stack {
     }
 
     const topic = new sns.Topic(this, 'MyTopic')
-    this.templateOptions.metadata.slicWatch.topicArn = topic.topicArn
+    this.templateOptions.metadata.slicWatch.alarmActionsConfig = {
+      alarmActions: topic.topicArn
+    }
 
     const helloFunction = new lambda.Function(this, 'HelloHandler',
       {

--- a/cdk-test-project/source/general-stack.ts
+++ b/cdk-test-project/source/general-stack.ts
@@ -41,7 +41,7 @@ export class CdkTestGeneralStack extends cdk.Stack {
 
     const topic = new sns.Topic(this, 'MyTopic')
     this.templateOptions.metadata.slicWatch.alarmActionsConfig = {
-      alarmActions: topic.topicArn
+      alarmActions: [topic.topicArn]
     }
 
     const helloFunction = new lambda.Function(this, 'HelloHandler',

--- a/cf-macro/index.ts
+++ b/cf-macro/index.ts
@@ -1,9 +1,9 @@
 import _ from 'lodash'
-import Ajv from 'ajv'
 import pino from 'pino'
 
-import { addAlarms, addDashboard, defaultConfig, slicWatchSchema, getResourcesByType } from '../core/index'
+import { addAlarms, addDashboard, getResourcesByType } from '../core/index'
 import { setLogger } from 'slic-watch-core/logging'
+import { type SlicWatchConfig, resolveSlicWatchConfig } from 'slic-watch-core/inputs/general-config'
 
 const logger = pino({ name: 'macroHandler' })
 setLogger(logger)
@@ -14,65 +14,44 @@ interface Event {
   fragment
 }
 
-interface SlicWatchConfig {
-  topicArn?: string
-  enabled?: boolean
-}
-
 // macro requires handler to be async
 export async function handler (event: Event) {
   let status = 'success'
+  let errorMessage: string | undefined
+
   logger.info({ event })
   const outputFragment = event.fragment
   try {
     const slicWatchConfig: SlicWatchConfig = outputFragment.Metadata?.slicWatch ?? {}
-    if (slicWatchConfig.enabled !== false) {
-      const ajv = new Ajv({
-        unicodeRegExp: false
-      })
-      const config = _.merge(defaultConfig, slicWatchConfig)
 
-      const slicWatchValidate = ajv.compile(slicWatchSchema)
-      const slicWatchValid = slicWatchValidate(slicWatchConfig)
+    const config = resolveSlicWatchConfig(slicWatchConfig)
 
-      if (!slicWatchValid) {
-        throw new Error('SLIC Watch configuration is invalid: ' + ajv.errorsText(slicWatchValidate.errors))
-      }
+    const functionAlarmConfigs = {}
+    const functionDashboardConfigs = {}
 
-      const alarmActions: string[] = []
-      slicWatchConfig?.topicArn != null && alarmActions.push(slicWatchConfig.topicArn)
-      process.env.ALARM_SNS_TOPIC != null && alarmActions.push(process.env.ALARM_SNS_TOPIC)
+    const lambdaResources = getResourcesByType('AWS::Lambda::Function', outputFragment)
 
-      const context = {
-        alarmActions
-      }
-      const functionAlarmConfigs = {}
-      const functionDashboardConfigs = {}
-
-      const lambdaResources = getResourcesByType(
-        'AWS::Lambda::Function',
-        outputFragment
-      )
-
-      for (const [funcResourceName, funcResource] of Object.entries(lambdaResources)) {
-        const funcConfig = funcResource.Metadata?.slicWatch ?? {}
-        functionAlarmConfigs[funcResourceName] = funcConfig.alarms ?? {}
-        functionDashboardConfigs[funcResourceName] = funcConfig.dashboard
-      }
-
-      _.merge(outputFragment)
-      addAlarms(config.alarms, functionAlarmConfigs, context, outputFragment)
-      addDashboard(config.dashboard, functionDashboardConfigs, outputFragment)
+    for (const [funcResourceName, funcResource] of Object.entries(lambdaResources)) {
+      const funcConfig = funcResource.Metadata?.slicWatch ?? {}
+      functionAlarmConfigs[funcResourceName] = funcConfig.alarms ?? {}
+      functionDashboardConfigs[funcResourceName] = funcConfig.dashboard
     }
+
+    _.merge(outputFragment)
+    addAlarms(config.alarms, functionAlarmConfigs, config.alarmActionsConfig, outputFragment)
+    addDashboard(config.dashboard, functionDashboardConfigs, outputFragment)
   } catch (err) {
     logger.error(err)
+    errorMessage = (err as Error).message
     status = 'fail'
   }
+
   logger.info({ outputFragment })
 
   return {
-    requestId: event.requestId,
     status,
+    errorMessage,
+    requestId: event.requestId,
     fragment: outputFragment
   }
 }

--- a/cf-macro/tests/index.test.ts
+++ b/cf-macro/tests/index.test.ts
@@ -64,7 +64,7 @@ test('Macro adds dashboard and alarms if no function configuration is provided',
       }
     }
   }
-  const compiledTemplate = await (await handler(testEvent)).fragment
+  const compiledTemplate = (await handler(testEvent)).fragment
   t.same(compiledTemplate.Resources.Properties, template.Resources?.Properties)
   t.end()
 })

--- a/cf-macro/tests/index.test.ts
+++ b/cf-macro/tests/index.test.ts
@@ -15,18 +15,9 @@ test('macro returns success', async t => {
   t.end()
 })
 
-test('macro uses SNS Topic environment variable if specified', async t => {
-  process.env.ALARM_SNS_TOPIC = 'arn:aws:sns:eu-west-1:123456789123:TestTopic'
-  try {
-    const result = await handler(event)
-    t.equal(result.status, 'success')
-  } finally {
-    delete process.env.ALARM_SNS_TOPIC
-  }
-  t.end()
-})
-
 test('macro uses topicArn if specified', async t => {
+  const topicArn = 'arn:aws:sns:eu-west-1:123456789123:TestTopic'
+
   const eventWithTopic = {
     ...event,
     fragment: {
@@ -35,13 +26,18 @@ test('macro uses topicArn if specified', async t => {
         ...event.fragment.Metadata,
         slicWatch: {
           ...event.fragment.Metadata?.slicWatch,
-          topicArn: 'arn:aws:sns:eu-west-1:123456789123:TestTopic'
+          alarmActionsConfig: {
+            alarmActions: [topicArn],
+            okActions: [topicArn]
+          }
         }
       }
     }
   }
   const result = await handler(eventWithTopic)
   t.equal(result.status, 'success')
+  t.notOk(result.errorMessage)
+  t.same(result.fragment.Resources.slicWatchLambdaDurationAlarmHelloLambdaFunction.Properties.AlarmActions, [topicArn])
   t.end()
 })
 
@@ -78,6 +74,7 @@ test('Macro execution fails if an invalid SLIC Watch config is provided', async 
   testevent.fragment.Metadata = { slicWatch: { topicArrrrn: 'pirateTopic' } }
   const result = await handler(testevent)
   t.equal(result.status, 'fail')
+  t.ok(result.errorMessage)
   t.end()
 })
 
@@ -91,6 +88,7 @@ test('Macro execution succeeds with no slicWatch config', t => {
 test('Macro execution succeeds if no SNS Topic is provided', t => {
   const testevent = _.cloneDeep(event)
   delete testevent.fragment.Metadata?.slicWatch.topicArn
+  delete testevent.fragment.Metadata?.slicWatch.alarmActionsConfig
   handler(testevent)
   t.end()
 })

--- a/core/alarms/alarm-types.ts
+++ b/core/alarms/alarm-types.ts
@@ -40,7 +40,9 @@ export interface ReturnAlarm {
 }
 
 export interface AlarmActionsConfig {
-  alarmActions: string[]
+  actionsEnabled?: boolean
+  okActions?: string[]
+  alarmActions?: string[]
 }
 
 export interface SlicWatchCascadedAlarmsConfig<T extends InputOutput> extends AlarmProperties {

--- a/core/alarms/alarm-utils.ts
+++ b/core/alarms/alarm-utils.ts
@@ -70,17 +70,18 @@ export function createCfAlarms (
  * Create a CloudFormation Alarm resourc
  *
  * @param alarmProperties The alarm configuration for this specific resource type
- * @param context Alarm actions
+ * @param alarmActionsConfig Alarm actions
  *
  * @returns An template object for the Cloudformation alarm
  */
 
-export function createAlarm (alarmProperties: AlarmProperties, context?: AlarmActionsConfig): AlarmTemplate {
+export function createAlarm (alarmProperties: AlarmProperties, alarmActionsConfig?: AlarmActionsConfig): AlarmTemplate {
   return {
     Type: 'AWS::CloudWatch::Alarm',
     Properties: {
-      ActionsEnabled: true,
-      AlarmActions: context?.alarmActions,
+      ActionsEnabled: alarmActionsConfig?.actionsEnabled,
+      AlarmActions: alarmActionsConfig?.alarmActions,
+      OKActions: alarmActionsConfig?.okActions,
       ...alarmProperties
     }
   }

--- a/core/alarms/alb-target-group.ts
+++ b/core/alarms/alb-target-group.ts
@@ -81,7 +81,7 @@ export function findLoadBalancersForTargetGroup (targetGroupLogicalId: string, c
  * @param metrics The Target Group metric names
  * @param loadBalancerLogicalIds The CloudFormation Logical IDs of the ALB resource
  * @param albTargetAlarmsConfig The fully resolved alarm configuration
- * @param alarmActionsConfig Deployment context (alarmActions)
+ * @param alarmActionsConfig Notification configuration for alarm status change events
  *
  * @returns ALB Target Group-specific CloudFormation Alarm resources
  */
@@ -120,23 +120,23 @@ function createAlbTargetCfAlarm (
  * based on the resources found within
  *
  * @param albTargetAlarmsConfig The fully resolved alarm configuration
- * @param context Deployment context (alarmActions)
+ * @param alarmActionsConfig Notification configuration for alarm status change events
  * @param compiledTemplate  A CloudFormation template object
  *
  * @returns ALB Target Group-specific CloudFormation Alarm resources
  */
 export default function createAlbTargetAlarms (
-  albTargetAlarmsConfig: SlicWatchAlbTargetAlarmsConfig<SlicWatchMergedConfig>, context: AlarmActionsConfig, compiledTemplate: Template
+  albTargetAlarmsConfig: SlicWatchAlbTargetAlarmsConfig<SlicWatchMergedConfig>, alarmActionsConfig: AlarmActionsConfig, compiledTemplate: Template
 ): CloudFormationResources {
   const targetGroupResources = getResourcesByType('AWS::ElasticLoadBalancingV2::TargetGroup', compiledTemplate)
   const resources: CloudFormationResources = {}
   for (const [targetGroupResourceName, targetGroupResource] of Object.entries(targetGroupResources)) {
     const loadBalancerLogicalIds = findLoadBalancersForTargetGroup(targetGroupResourceName, compiledTemplate)
-    Object.assign(resources, createAlbTargetCfAlarm(targetGroupResourceName, executionMetrics, loadBalancerLogicalIds, albTargetAlarmsConfig, context))
+    Object.assign(resources, createAlbTargetCfAlarm(targetGroupResourceName, executionMetrics, loadBalancerLogicalIds, albTargetAlarmsConfig, alarmActionsConfig))
 
     if (targetGroupResource.Properties?.TargetType === 'lambda') {
       // Create additional alarms for Lambda-specific ALB metrics
-      Object.assign(resources, createAlbTargetCfAlarm(targetGroupResourceName, executionMetricsLambda, loadBalancerLogicalIds, albTargetAlarmsConfig, context))
+      Object.assign(resources, createAlbTargetCfAlarm(targetGroupResourceName, executionMetricsLambda, loadBalancerLogicalIds, albTargetAlarmsConfig, alarmActionsConfig))
     }
   }
   return resources

--- a/core/alarms/alb.ts
+++ b/core/alarms/alb.ts
@@ -34,20 +34,20 @@ function createAlbAlarmCfProperties (metric: string, albLogicalId: string, confi
  * based on the resources found within
  *
  * @param albAlarmsConfig The fully resolved alarm configuration
- * @param context Deployment context (alarmActions)
+ * @param alarmActionsConfig Notification configuration for alarm status change events
  * @param compiledTemplate  A CloudFormation template object
  *
  * @returns ALB-specific CloudFormation Alarm resources
  */
 export default function createAlbAlarms (
-  albAlarmsConfig: SlicWatchAlbAlarmsConfig<SlicWatchMergedConfig>, context: AlarmActionsConfig, compiledTemplate: Template
+  albAlarmsConfig: SlicWatchAlbAlarmsConfig<SlicWatchMergedConfig>, alarmActionsConfig: AlarmActionsConfig, compiledTemplate: Template
 ): CloudFormationResources {
   return createCfAlarms(
     'AWS::ElasticLoadBalancingV2::LoadBalancer',
     'LoadBalancer',
     executionMetrics,
     albAlarmsConfig,
-    context,
+    alarmActionsConfig,
     compiledTemplate,
     createAlbAlarmCfProperties
   )

--- a/core/alarms/api-gateway.ts
+++ b/core/alarms/api-gateway.ts
@@ -74,7 +74,7 @@ const executionMetrics = ['5XXError', '4XXError', 'Latency']
  * Add all required API Gateway REST API alarms to the provided CloudFormation template based on the resources found within
  *
  * @param apiGwAlarmsConfig The fully resolved alarm configuration
- * @param alarmActionsConfig Deployment context (alarmActions)
+ * @param alarmActionsConfig Notification configuration for alarm status change events
  * @param compiledTemplate  A CloudFormation template object
  *
  * @returns API Gateway-specific CloudFormation Alarm resources

--- a/core/alarms/appsync.ts
+++ b/core/alarms/appsync.ts
@@ -18,7 +18,7 @@ const executionMetrics = ['5XXError', 'Latency']
  * based on the AppSync resources found within
  *
  * @param appSyncAlarmsConfig The fully resolved alarm configuration
- * @param alarmActionsConfig Deployment context (alarmActions)
+ * @param alarmActionsConfig Notification configuration for alarm status change events
  * @param compiledTemplate  A CloudFormation template object
  *
  * @returns AppSync-specific CloudFormation Alarm resources

--- a/core/alarms/dynamodb.ts
+++ b/core/alarms/dynamodb.ts
@@ -21,13 +21,13 @@ const dynamoDbGsiMetrics = ['ReadThrottleEvents', 'WriteThrottleEvents']
  * based on the tables and any global secondary indices (GSIs).
  *
  * @param dynamoDbAlarmsConfig The fully resolved alarm configuration
- * @param context Deployment context (alarmActions)
+ * @param alarmActionsConfig Notification configuration for alarm status change events
  * @param compiledTemplate  A CloudFormation template object
  *
  * @returns DynamoDB-specific CloudFormation Alarm resources
  */
 export default function createDynamoDbAlarms (
-  dynamoDbAlarmsConfig: SlicWatchDynamoDbAlarmsConfig<SlicWatchMergedConfig>, context: AlarmActionsConfig, compiledTemplate: Template
+  dynamoDbAlarmsConfig: SlicWatchDynamoDbAlarmsConfig<SlicWatchMergedConfig>, alarmActionsConfig: AlarmActionsConfig, compiledTemplate: Template
 ): CloudFormationResources {
   const resources: CloudFormationResources = {}
   const tableResources = getResourcesByType('AWS::DynamoDB::Table', compiledTemplate)
@@ -46,7 +46,7 @@ export default function createDynamoDbAlarms (
           ...rest
         }
         const alarmLogicalId = makeAlarmLogicalId('Table', tableLogicalId, metric)
-        const resource = createAlarm(dynamoDbAlarmProperties, context)
+        const resource = createAlarm(dynamoDbAlarmProperties, alarmActionsConfig)
         resources[alarmLogicalId] = resource
       }
     }
@@ -66,7 +66,7 @@ export default function createDynamoDbAlarms (
             ...rest
           }
           const alarmLogicalId = makeAlarmLogicalId('GSI', `${tableLogicalId}${gsiName}`, metric)
-          const resource = createAlarm(dynamoDbAlarmsConfig, context)
+          const resource = createAlarm(dynamoDbAlarmsConfig, alarmActionsConfig)
           resources[alarmLogicalId] = resource
         }
       }

--- a/core/alarms/ecs.ts
+++ b/core/alarms/ecs.ts
@@ -40,13 +40,13 @@ const executionMetrics = ['MemoryUtilization', 'CPUUtilization']
  * based on the ECS Service resources
  *
  * @param ecsAlarmsConfig The fully resolved alarm configuration
- * @param context Deployment context (alarmActions)
+ * @param alarmActionsConfig Notification configuration for alarm status change events
  * @param compiledTemplate  A CloudFormation template object
  *
  * @returns ECS-specific CloudFormation Alarm resources
  */
 export default function createECSAlarms (
-  ecsAlarmsConfig: SlicWatchEcsAlarmsConfig<SlicWatchMergedConfig>, context: AlarmActionsConfig, compiledTemplate: Template
+  ecsAlarmsConfig: SlicWatchEcsAlarmsConfig<SlicWatchMergedConfig>, alarmActionsConfig: AlarmActionsConfig, compiledTemplate: Template
 ): CloudFormationResources {
   const resources: CloudFormationResources = {}
   const serviceResources = getResourcesByType('AWS::ECS::Service', compiledTemplate)
@@ -70,7 +70,7 @@ export default function createECSAlarms (
           ...rest
         }
         const resourceName = `slicWatchECS${metric.replaceAll('Utilization', 'Alarm')}${serviceLogicalId}`
-        const resource = createAlarm(ecsAlarmProperties, context)
+        const resource = createAlarm(ecsAlarmProperties, alarmActionsConfig)
         resources[resourceName] = resource
       }
     }

--- a/core/alarms/eventbridge.ts
+++ b/core/alarms/eventbridge.ts
@@ -34,20 +34,20 @@ function createEventBridgeAlarmCfProperties (metric: string, ruleLogicalId: stri
  * based on the EventBridge Rule found within
  *
  * @param eventsAlarmsConfig The fully resolved alarm configuration
- * @param context Deployment context (alarmActions)
+ * @param alarmActionsConfig Notification configuration for alarm status change events
  * @param compiledTemplate  A CloudFormation template object
  *
  * @returns EventBridge-specific CloudFormation Alarm resources
  */
 export default function createRuleAlarms (
-  eventsAlarmsConfig: SlicWatchEventsAlarmsConfig<SlicWatchMergedConfig>, context: AlarmActionsConfig, compiledTemplate: Template
+  eventsAlarmsConfig: SlicWatchEventsAlarmsConfig<SlicWatchMergedConfig>, alarmActionsConfig: AlarmActionsConfig, compiledTemplate: Template
 ): CloudFormationResources {
   return createCfAlarms(
     'AWS::Events::Rule',
     'Events',
     executionMetrics,
     eventsAlarmsConfig,
-    context,
+    alarmActionsConfig,
     compiledTemplate,
     createEventBridgeAlarmCfProperties
   )

--- a/core/alarms/kinesis.ts
+++ b/core/alarms/kinesis.ts
@@ -30,13 +30,13 @@ const kinesisAlarmTypes = {
  * based on the resources found within
 *
  * @param kinesisAlarmsConfig The fully resolved alarm configuration for Kinesis Data Streams
- * @param context Deployment context (alarmActions)
+ * @param alarmActionsConfig Notification configuration for alarm status change events
  * @param compiledTemplate  A CloudFormation template object
  *
  * @returns Kinesis Data Stream-specific CloudFormation Alarm resources
  */
 export default function createKinesisAlarms (
-  kinesisAlarmsConfig: SlicWatchKinesisAlarmsConfig<SlicWatchMergedConfig>, context: AlarmActionsConfig, compiledTemplate: Template
+  kinesisAlarmsConfig: SlicWatchKinesisAlarmsConfig<SlicWatchMergedConfig>, alarmActionsConfig: AlarmActionsConfig, compiledTemplate: Template
 ): CloudFormationResources {
   const resources: CloudFormationResources = {}
   const streamResources = getResourcesByType('AWS::Kinesis::Stream', compiledTemplate)
@@ -55,7 +55,7 @@ export default function createKinesisAlarms (
           ...rest
         }
         const alarmLogicalId = makeAlarmLogicalId('Kinesis', pascal(streamLogicalId), type)
-        const resource = createAlarm(kinesisAlarmProperties, context)
+        const resource = createAlarm(kinesisAlarmProperties, alarmActionsConfig)
         resources[alarmLogicalId] = resource
       }
     }

--- a/core/alarms/sns.ts
+++ b/core/alarms/sns.ts
@@ -32,20 +32,20 @@ function createSnsTopicAlarmCfProperties (metric: string, snsLogicalId: string, 
  * Add all required SNS alarms to the provided CloudFormation template
  *
  * @param snsAlarmsConfig The fully resolved alarm configuration
- * @param context Deployment context (alarmActions)
+ * @param alarmActionsConfig Notification configuration for alarm status change events
  * @param compiledTemplate A CloudFormation template object
  *
  * @returns SNS-specific CloudFormation Alarm resources
  */
 export default function createSnsAlarms (
-  snsAlarmsConfig: SlicWatchSnsAlarmsConfig<SlicWatchMergedConfig>, context: AlarmActionsConfig, compiledTemplate: Template
+  snsAlarmsConfig: SlicWatchSnsAlarmsConfig<SlicWatchMergedConfig>, alarmActionsConfig: AlarmActionsConfig, compiledTemplate: Template
 ): CloudFormationResources {
   return createCfAlarms(
     'AWS::SNS::Topic',
     'SNS',
     executionMetrics,
     snsAlarmsConfig,
-    context,
+    alarmActionsConfig,
     compiledTemplate,
     createSnsTopicAlarmCfProperties
   )

--- a/core/alarms/sqs.ts
+++ b/core/alarms/sqs.ts
@@ -16,13 +16,13 @@ export interface SlicWatchSqsAlarmsConfig<T extends InputOutput> extends SlicWat
  * based on the SQS resources found within
  *
  * @param sqsAlarmsConfig The fully resolved alarm configuration
- * @param context Deployment context (alarmActions)
+ * @param alarmActionsConfig Notification configuration for alarm status change events
  * @param compiledTemplate  A CloudFormation template object
  *
  * @returns SQS-specific CloudFormation Alarm resources
  */
 export default function createSQSAlarms (
-  sqsAlarmsConfig: SlicWatchSqsAlarmsConfig<SlicWatchMergedConfig>, context: AlarmActionsConfig, compiledTemplate: Template
+  sqsAlarmsConfig: SlicWatchSqsAlarmsConfig<SlicWatchMergedConfig>, alarmActionsConfig: AlarmActionsConfig, compiledTemplate: Template
 ): CloudFormationResources {
   const resources: CloudFormationResources = {}
   const queueResources = getResourcesByType('AWS::SQS::Queue', compiledTemplate)
@@ -46,7 +46,7 @@ export default function createSQSAlarms (
         Threshold: thresholdValue
       }
       const resourceName = `slicWatchSQSInFlightMsgsAlarm${queueLogicalId}`
-      const resource = createAlarm(sqsAlarmProperties, context)
+      const resource = createAlarm(sqsAlarmProperties, alarmActionsConfig)
       resources[resourceName] = resource
     }
 
@@ -66,7 +66,7 @@ export default function createSQSAlarms (
         ...alarmProps
       }
       const resourceName = `slicWatchSQSOldestMsgAgeAlarm${queueLogicalId}`
-      const resource = createAlarm(sqsAlarmProperties, context)
+      const resource = createAlarm(sqsAlarmProperties, alarmActionsConfig)
       resources[resourceName] = resource
     }
   }

--- a/core/alarms/step-functions.ts
+++ b/core/alarms/step-functions.ts
@@ -34,20 +34,20 @@ function createStepFunctionAlarmCfProperties (metric: string, sfLogicalId: strin
  * based on the resources found within
  *
  * @param sfAlarmProperties The fully resolved States alarm configuration
- * @param context Deployment context (alarmActions)
+ * @param alarmActionsConfig Notification configuration for alarm status change events
  * @param compiledTemplate  A CloudFormation template object
  *
  * @returns Step Function-specific CloudFormation Alarm resources
 */
 export default function createStatesAlarms (
-  sfAlarmProperties: SlicWatchSfAlarmsConfig<SlicWatchMergedConfig>, context: AlarmActionsConfig, compiledTemplate: Template
+  sfAlarmProperties: SlicWatchSfAlarmsConfig<SlicWatchMergedConfig>, alarmActionsConfig: AlarmActionsConfig, compiledTemplate: Template
 ): CloudFormationResources {
   return createCfAlarms(
     'AWS::StepFunctions::StateMachine',
     'States',
     executionMetrics,
     sfAlarmProperties,
-    context,
+    alarmActionsConfig,
     compiledTemplate,
     createStepFunctionAlarmCfProperties
   )

--- a/core/alarms/tests/alarms.test.ts
+++ b/core/alarms/tests/alarms.test.ts
@@ -2,7 +2,7 @@ import { test } from 'tap'
 
 import addAlarms from '../alarms'
 import defaultConfig from '../../inputs/default-config'
-import { createTestCloudFormationTemplate, albCfTemplate, createTestConfig, testContext } from '../../tests/testing-utils'
+import { createTestCloudFormationTemplate, albCfTemplate, createTestConfig, testAlarmActionsConfig } from '../../tests/testing-utils'
 import { getResourcesByType } from '../../cf-template'
 
 test('Alarms create all service alarms', (t) => {
@@ -11,7 +11,7 @@ test('Alarms create all service alarms', (t) => {
   for (const funcLogicalId of Object.keys(getResourcesByType('AWS::Lambda::Function', compiledTemplate))) {
     funcAlarmPropertiess[funcLogicalId] = {}
   }
-  addAlarms(defaultConfig.alarms, funcAlarmPropertiess, testContext, compiledTemplate)
+  addAlarms(defaultConfig.alarms, funcAlarmPropertiess, testAlarmActionsConfig, compiledTemplate)
   const namespaces = new Set()
   for (const resource of Object.values(
     getResourcesByType('AWS::CloudWatch::Alarm', compiledTemplate)
@@ -30,7 +30,7 @@ test('Alarms create all ALB service alarms', (t) => {
   for (const funcLogicalId of Object.keys(getResourcesByType('AWS::Lambda::Function', compiledTemplate))) {
     funcAlarmPropertiess[funcLogicalId] = {}
   }
-  addAlarms(defaultConfig.alarms, funcAlarmPropertiess, testContext, compiledTemplate)
+  addAlarms(defaultConfig.alarms, funcAlarmPropertiess, testAlarmActionsConfig, compiledTemplate)
   const namespaces = new Set()
   for (const resource of Object.values(
     getResourcesByType('AWS::CloudWatch::Alarm', compiledTemplate)
@@ -55,7 +55,7 @@ test('Alarms are not created when disabled globally', (t) => {
   for (const funcLogicalId of Object.keys(getResourcesByType('AWS::Lambda::Function', compiledTemplate))) {
     funcAlarmPropertiess[funcLogicalId] = {}
   }
-  addAlarms(config, funcAlarmPropertiess, testContext, compiledTemplate)
+  addAlarms(config, funcAlarmPropertiess, testAlarmActionsConfig, compiledTemplate)
 
   const alarmsCreated = getResourcesByType('AWS::CloudWatch::Alarm', compiledTemplate)
 

--- a/core/alarms/tests/alb-target-group.test.ts
+++ b/core/alarms/tests/alb-target-group.test.ts
@@ -8,7 +8,7 @@ import {
   createTestConfig,
   createTestCloudFormationTemplate,
   albCfTemplate,
-  testContext
+  testAlarmActionsConfig
 } from '../../tests/testing-utils'
 import type { ResourceType } from '../../cf-template'
 
@@ -216,7 +216,7 @@ test('ALB Target Group alarms are created', (t) => {
   const albAlarmProperties = AlarmPropertiesTargetGroup.ApplicationELBTarget
   const compiledTemplate = createTestCloudFormationTemplate(albCfTemplate)
 
-  const targetGroupAlarmResources: ResourceType = createAlbTargetAlarms(albAlarmProperties, testContext, compiledTemplate)
+  const targetGroupAlarmResources: ResourceType = createAlbTargetAlarms(albAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   const expectedTypesTargetGroup = {
     LoadBalancer_HTTPCodeTarget5XXCountAlarm: 'HTTPCode_Target_5XX_Count',
@@ -291,7 +291,7 @@ test('ALB alarms are not created when disabled globally', (t) => {
 
   const albAlarmProperties = AlarmPropertiesTargetGroup.ApplicationELBTarget
   const compiledTemplate = createTestCloudFormationTemplate(albCfTemplate)
-  const targetGroupAlarmResources = createAlbTargetAlarms(albAlarmProperties, testContext, compiledTemplate)
+  const targetGroupAlarmResources = createAlbTargetAlarms(albAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   t.same({}, targetGroupAlarmResources)
   t.end()

--- a/core/alarms/tests/alb.test.ts
+++ b/core/alarms/tests/alb.test.ts
@@ -9,7 +9,7 @@ import {
   createTestConfig,
   createTestCloudFormationTemplate,
   albCfTemplate,
-  testContext
+  testAlarmActionsConfig
 } from '../../tests/testing-utils'
 import type { ResourceType } from '../../cf-template'
 import type { SlicWatchMergedConfig } from '../alarm-types'
@@ -35,7 +35,7 @@ test('ALB alarms are created', (t) => {
   )
   function createAlarmResources (elbAlarmProperties: SlicWatchAlbAlarmsConfig<SlicWatchMergedConfig>) {
     const compiledTemplate = createTestCloudFormationTemplate(albCfTemplate)
-    return createAlbAlarms(elbAlarmProperties, testContext, compiledTemplate)
+    return createAlbAlarms(elbAlarmProperties, testAlarmActionsConfig, compiledTemplate)
   }
   const albAlarmResources: ResourceType = createAlarmResources(AlarmPropertiesELB.ApplicationELB)
 
@@ -94,7 +94,7 @@ test('ALB alarms are not created when disabled globally', (t) => {
 
   function createAlarmResources (elbAlarmProperties) {
     const compiledTemplate = createTestCloudFormationTemplate(albCfTemplate)
-    return createAlbAlarms(elbAlarmProperties, testContext, compiledTemplate)
+    return createAlbAlarms(elbAlarmProperties, testAlarmActionsConfig, compiledTemplate)
   }
   const albAlarmResources = createAlarmResources(AlarmPropertiesELB.ApplicationELB)
 

--- a/core/alarms/tests/api-gateway.test.ts
+++ b/core/alarms/tests/api-gateway.test.ts
@@ -7,7 +7,7 @@ import {
   alarmNameToType,
   createTestConfig,
   createTestCloudFormationTemplate,
-  testContext
+  testAlarmActionsConfig
 } from '../../tests/testing-utils'
 import type { ResourceType } from '../../cf-template'
 import type Resource from 'cloudform-types/types/resource'
@@ -115,7 +115,7 @@ test('API Gateway alarms are created', (t) => {
   t.test('with full template', (t) => {
     const compiledTemplate = createTestCloudFormationTemplate()
 
-    const alarmResources: ResourceType = createApiGatewayAlarms(apiGwAlarmProperties, testContext, compiledTemplate)
+    const alarmResources: ResourceType = createApiGatewayAlarms(apiGwAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
     const alarmsByType: AlarmsByType = {}
     t.equal(Object.keys(alarmResources).length, 3)
@@ -209,7 +209,7 @@ test('API Gateway alarms are created', (t) => {
     const apiGwAlarmProperties = AlarmProperties.ApiGateway
     const compiledTemplate = createTestCloudFormationTemplate()
 
-    const alarmResources = createApiGatewayAlarms(apiGwAlarmProperties, testContext, compiledTemplate)
+    const alarmResources = createApiGatewayAlarms(apiGwAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
     t.same({}, alarmResources)
     t.end()
@@ -226,7 +226,7 @@ test('API Gateway alarms are created', (t) => {
         }
       }
     })
-    const alarmResources: ResourceType = createApiGatewayAlarms(apiGwAlarmProperties, testContext, compiledTemplate)
+    const alarmResources: ResourceType = createApiGatewayAlarms(apiGwAlarmProperties, testAlarmActionsConfig, compiledTemplate)
     t.same(Object.keys(alarmResources).sort(), [
       'slicWatchApi4XXErrorAlarmAWSStackName',
       'slicWatchApi5XXErrorAlarmAWSStackName',
@@ -262,7 +262,7 @@ test('API Gateway alarms are not created when disabled individually', (t) => {
   const apiGwAlarmProperties = AlarmProperties.ApiGateway
   const compiledTemplate = createTestCloudFormationTemplate()
 
-  const alarmResources = createApiGatewayAlarms(apiGwAlarmProperties, testContext, compiledTemplate)
+  const alarmResources = createApiGatewayAlarms(apiGwAlarmProperties, testAlarmActionsConfig, compiledTemplate)
   t.same({}, alarmResources)
   t.end()
 })
@@ -271,7 +271,7 @@ test('Alarm Resource Id should have a postfix using the Name of the Api', (t) =>
   const testConfig = createTestConfig(defaultConfig.alarms, {})
   const apiGatewayResource: Resource = { Type: 'AWS::ApiGateway::RestApi', Properties: { Name: 'SimpleTest' } }
   const Resources: Record<string, Resource> = { test: apiGatewayResource }
-  const apiGatewayAlarms = createApiGatewayAlarms(testConfig.ApiGateway, testContext, { Resources })
+  const apiGatewayAlarms = createApiGatewayAlarms(testConfig.ApiGateway, testAlarmActionsConfig, { Resources })
   t.same(Object.keys(apiGatewayAlarms), ['slicWatchApi5XXErrorAlarmSimpleTest', 'slicWatchApi4XXErrorAlarmSimpleTest', 'slicWatchApiLatencyAlarmSimpleTest'])
   t.end()
 })
@@ -280,7 +280,7 @@ test('Alarm Resource Id should have a postfix using the Title of the Api Body', 
   const testConfig = createTestConfig(defaultConfig.alarms, {})
   const apiGatewayResource: Resource = { Type: 'AWS::ApiGateway::RestApi', Properties: { Body: { info: { title: 'UsingTitle' } } } }
   const Resources: Record<string, Resource> = { test: apiGatewayResource }
-  const apiGatewayAlarms = createApiGatewayAlarms(testConfig.ApiGateway, testContext, { Resources })
+  const apiGatewayAlarms = createApiGatewayAlarms(testConfig.ApiGateway, testAlarmActionsConfig, { Resources })
   t.same(Object.keys(apiGatewayAlarms), ['slicWatchApi5XXErrorAlarmUsingTitle', 'slicWatchApi4XXErrorAlarmUsingTitle', 'slicWatchApiLatencyAlarmUsingTitle'])
   t.end()
 })

--- a/core/alarms/tests/appsync.test.ts
+++ b/core/alarms/tests/appsync.test.ts
@@ -9,7 +9,7 @@ import {
   createTestConfig,
   createTestCloudFormationTemplate,
   appSyncCfTemplate,
-  testContext
+  testAlarmActionsConfig
 } from '../../tests/testing-utils'
 import type { ResourceType } from '../../cf-template'
 import type { SlicWatchMergedConfig } from '../alarm-types'
@@ -35,7 +35,7 @@ test('AppSync alarms are created', (t) => {
   )
   function createAlarmResources (appSyncAlarmProperties: SlicWatchAppSyncAlarmsConfig<SlicWatchMergedConfig>) {
     const compiledTemplate = createTestCloudFormationTemplate(appSyncCfTemplate)
-    return createAppSyncAlarms(appSyncAlarmProperties, testContext, compiledTemplate)
+    return createAppSyncAlarms(appSyncAlarmProperties, testAlarmActionsConfig, compiledTemplate)
   }
   const appSyncAlarmResources: ResourceType = createAlarmResources(AlarmPropertiesAppSync.AppSync)
 
@@ -94,7 +94,7 @@ test('AppSync alarms are not created when disabled globally', (t) => {
 
   function createAlarmResources (appSyncAlarmProperties) {
     const compiledTemplate = createTestCloudFormationTemplate(appSyncCfTemplate)
-    return createAppSyncAlarms(appSyncAlarmProperties, testContext, compiledTemplate)
+    return createAppSyncAlarms(appSyncAlarmProperties, testAlarmActionsConfig, compiledTemplate)
   }
   const appSyncAlarmResources = createAlarmResources(AlarmPropertiesAppSync.AppSync)
 

--- a/core/alarms/tests/dynamodb.test.ts
+++ b/core/alarms/tests/dynamodb.test.ts
@@ -9,7 +9,7 @@ import {
   alarmNameToType,
   createTestConfig,
   createTestCloudFormationTemplate,
-  testContext,
+  testAlarmActionsConfig,
   defaultCfTemplate
 } from '../../tests/testing-utils'
 
@@ -40,7 +40,7 @@ const dynamoDbAlarmProperties = AlarmProperties.DynamoDB
 ;[true, false].forEach(specifyTableName => {
   test(`DynamoDB alarms are created ${specifyTableName ? 'with' : 'without'} a table name property`, (t) => {
     const compiledTemplate = createTestCloudFormationTemplate()
-    const resources = createDynamoDbAlarms(dynamoDbAlarmProperties, testContext, compiledTemplate)
+    const resources = createDynamoDbAlarms(dynamoDbAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
     for (const resourceName in resources) {
       addResource(resourceName, resources[resourceName], compiledTemplate)
@@ -101,7 +101,7 @@ test('DynamoDB alarms are created without GSI', (t) => {
   const compiledTemplate = createTestCloudFormationTemplate()
   _.cloneDeep(defaultCfTemplate)
   delete compiledTemplate.Resources?.dataTable.Properties?.GlobalSecondaryIndexes
-  const resources = createDynamoDbAlarms(dynamoDbAlarmProperties, testContext, compiledTemplate)
+  const resources = createDynamoDbAlarms(dynamoDbAlarmProperties, testAlarmActionsConfig, compiledTemplate)
   for (const resourceName in resources) {
     addResource(resourceName, resources[resourceName], compiledTemplate)
   }
@@ -120,7 +120,7 @@ test('DynamoDB alarms are not created when disabled', (t) => {
   const dynamoDbAlarmProperties = AlarmProperties.DynamoDB
   const compiledTemplate = createTestCloudFormationTemplate()
 
-  const alarmResources = createDynamoDbAlarms(dynamoDbAlarmProperties, testContext, compiledTemplate)
+  const alarmResources = createDynamoDbAlarms(dynamoDbAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   t.same({}, alarmResources)
   t.end()

--- a/core/alarms/tests/ecs.test.ts
+++ b/core/alarms/tests/ecs.test.ts
@@ -7,7 +7,7 @@ import {
   alarmNameToType,
   createTestConfig,
   createTestCloudFormationTemplate,
-  testContext
+  testAlarmActionsConfig
 } from '../../tests/testing-utils'
 import type { ResourceType } from '../../cf-template'
 
@@ -51,7 +51,7 @@ test('ECS MemoryUtilization is created', (t) => {
   const ecsAlarmProperties = AlarmProperties.ECS
   const compiledTemplate = createTestCloudFormationTemplate()
 
-  const alarmResources: ResourceType = createECSAlarms(ecsAlarmProperties, testContext, compiledTemplate)
+  const alarmResources: ResourceType = createECSAlarms(ecsAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   const expectedTypes = {
     ECS_MemoryAlarm: 'MemoryUtilization',
@@ -112,7 +112,7 @@ test('ECS alarms are not created when disabled globally', (t) => {
   const ecsAlarmProperties = AlarmProperties.ECS
   const compiledTemplate = createTestCloudFormationTemplate()
 
-  const alarmResources = createECSAlarms(ecsAlarmProperties, testContext, compiledTemplate)
+  const alarmResources = createECSAlarms(ecsAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   t.same({}, alarmResources)
   t.end()

--- a/core/alarms/tests/eventbridge.test.ts
+++ b/core/alarms/tests/eventbridge.test.ts
@@ -9,7 +9,7 @@ import {
   alarmNameToType,
   createTestConfig,
   createTestCloudFormationTemplate,
-  testContext
+  testAlarmActionsConfig
 } from '../../tests/testing-utils'
 
 test('Events alarms are created', (t) => {
@@ -32,7 +32,7 @@ test('Events alarms are created', (t) => {
   )
   const ruleAlarmProperties = AlarmProperties.Events
   const compiledTemplate = createTestCloudFormationTemplate()
-  const alarmResources: ResourceType = createRuleAlarms(ruleAlarmProperties, testContext, compiledTemplate)
+  const alarmResources: ResourceType = createRuleAlarms(ruleAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   const expectedTypes = {
     Events_FailedInvocations_Alarm: 'FailedInvocations',
@@ -79,7 +79,7 @@ test('Events alarms are not created when disabled globally', (t) => {
   )
   const ruleAlarmProperties = AlarmProperties.Events
   const compiledTemplate = createTestCloudFormationTemplate()
-  createRuleAlarms(ruleAlarmProperties, testContext, compiledTemplate)
+  createRuleAlarms(ruleAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   const alarmResources = getResourcesByType('AWS::CloudWatch::Alarm', compiledTemplate)
 

--- a/core/alarms/tests/kinesis.test.ts
+++ b/core/alarms/tests/kinesis.test.ts
@@ -10,7 +10,7 @@ import {
   alarmNameToType,
   createTestConfig,
   createTestCloudFormationTemplate,
-  testContext
+  testAlarmActionsConfig
 } from '../../tests/testing-utils'
 
 test('Kinesis data stream alarms are created', (t) => {
@@ -30,7 +30,7 @@ test('Kinesis data stream alarms are created', (t) => {
   )
   const kinesisAlarmProperties = AlarmProperties.Kinesis
   const compiledTemplate = createTestCloudFormationTemplate()
-  const alarmResources: ResourceType = createKinesisAlarms(kinesisAlarmProperties, testContext, compiledTemplate)
+  const alarmResources: ResourceType = createKinesisAlarms(kinesisAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   const expectedTypes = {
     Kinesis_StreamIteratorAge: 'GetRecords.IteratorAgeMilliseconds',
@@ -84,7 +84,7 @@ test('Kinesis data stream alarms are not created when disabled globally', (t) =>
   )
   const kinesisAlarmProperties = AlarmProperties.Kinesis
   const compiledTemplate = createTestCloudFormationTemplate()
-  createKinesisAlarms(kinesisAlarmProperties, testContext, compiledTemplate)
+  createKinesisAlarms(kinesisAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   const alarmResources = getResourcesByType('AWS::CloudWatch::Alarm', compiledTemplate)
 

--- a/core/alarms/tests/lambda.test.ts
+++ b/core/alarms/tests/lambda.test.ts
@@ -12,7 +12,7 @@ import {
   createTestConfig,
   createTestCloudFormationTemplate,
   albCfTemplate,
-  testContext
+  testAlarmActionsConfig
 } from '../../tests/testing-utils'
 import { applyAlarmConfig } from '../../inputs/function-config'
 
@@ -60,7 +60,7 @@ test('AWS Lambda alarms are created', (t) => {
     FunctionAlarmProperties[funcLogicalId] = AlarmProperties.Lambda
   }
 
-  const alarmResources: ResourceType = createLambdaAlarms(FunctionAlarmProperties, testContext, compiledTemplate)
+  const alarmResources: ResourceType = createLambdaAlarms(FunctionAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   function getAlarmsByType (): AlarmsByType {
     const alarmsByType = {}
@@ -173,7 +173,7 @@ test('AWS Lambda alarms are created for ALB', (t) => {
   for (const funcLogicalId of Object.keys(getResourcesByType('AWS::Lambda::Function', compiledTemplate))) {
     albFunctionAlarmProperties[funcLogicalId] = AlarmProperties.Lambda
   }
-  const albAlarmResources: ResourceType = createLambdaAlarms(albFunctionAlarmProperties, testContext, compiledTemplate)
+  const albAlarmResources: ResourceType = createLambdaAlarms(albFunctionAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   function getAlarmsByType (): AlarmsByType {
     const albAlarmsByType: AlarmsByType = {}
@@ -269,7 +269,7 @@ test('Invocation alarms are created if configured', (t) => {
     FunctionAlarmProperties[funcLogicalId] = AlarmProperties.Lambda
   }
 
-  const alarmResources = createLambdaAlarms(FunctionAlarmProperties, testContext, compiledTemplate)
+  const alarmResources = createLambdaAlarms(FunctionAlarmProperties, testAlarmActionsConfig, compiledTemplate)
   const invocAlarmResources: ResourceType = filterObject(
     alarmResources,
     (res) => res.Properties.AlarmName.payload[0].startsWith('Lambda_Invocations')
@@ -315,7 +315,7 @@ test('Invocation alarms throws if misconfigured (enabled but no threshold set)',
   for (const funcLogicalId of Object.keys(getResourcesByType('AWS::Lambda::Function', compiledTemplate))) {
     FunctionAlarmProperties[funcLogicalId] = AlarmProperties.Lambda
   }
-  createLambdaAlarms(FunctionAlarmProperties, testContext, compiledTemplate)
+  createLambdaAlarms(FunctionAlarmProperties, testAlarmActionsConfig, compiledTemplate)
   t.end()
 })
 
@@ -371,7 +371,7 @@ test('Invocation alarms throws if misconfigured (enabled but no threshold set)',
     for (const funcLogicalId of Object.keys(getResourcesByType('AWS::Lambda::Function', compiledTemplate))) {
       FunctionAlarmProperties[funcLogicalId] = AlarmProperties.Lambda
     }
-    createLambdaAlarms(FunctionAlarmProperties, testContext, compiledTemplate)
+    createLambdaAlarms(FunctionAlarmProperties, testAlarmActionsConfig, compiledTemplate)
     const alarmResources = getResourcesByType('AWS::CloudWatch::Alarm', compiledTemplate)
     t.equal(Object.keys(alarmResources).length, 0)
     t.end()
@@ -406,7 +406,7 @@ test('Lambda alarms are not created when disabled globally', (t) => {
   for (const funcLogicalId of Object.keys(getResourcesByType('AWS::Lambda::Function', compiledTemplate))) {
     FunctionAlarmProperties[funcLogicalId] = AlarmProperties.Lambda
   }
-  createLambdaAlarms(FunctionAlarmProperties, testContext, compiledTemplate)
+  createLambdaAlarms(FunctionAlarmProperties, testAlarmActionsConfig, compiledTemplate)
   const alarmResources = getResourcesByType('AWS::CloudWatch::Alarm', compiledTemplate)
 
   t.same({}, alarmResources)
@@ -446,7 +446,7 @@ test('Lambda alarms are not created when disabled individually', (t) => {
   for (const funcLogicalId of Object.keys(getResourcesByType('AWS::Lambda::Function', compiledTemplate))) {
     FunctionAlarmProperties[funcLogicalId] = AlarmProperties.Lambda
   }
-  createLambdaAlarms(FunctionAlarmProperties, testContext, compiledTemplate)
+  createLambdaAlarms(FunctionAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   const alarmResources = getResourcesByType('AWS::CloudWatch::Alarm', compiledTemplate)
 
@@ -483,7 +483,7 @@ test('AWS Lambda alarms are not created if disabled at function level', (t) => {
     AlarmProperties.Lambda, {
       HelloLambdaFunction: { Lambda: { enabled: false } }
     })
-  createLambdaAlarms(disabledFunctionAlarmProperties, testContext, compiledTemplate)
+  createLambdaAlarms(disabledFunctionAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   const alarmResources = getResourcesByType('AWS::CloudWatch::Alarm', compiledTemplate)
   t.equal(Object.keys(alarmResources).length, 0)
@@ -506,7 +506,7 @@ test('AWS Lambda alarms are not created if function configuration is not provide
     funcAlarmProperties.Lambda, {
       HelloLambdaFunction: { Lambda: { enabled: false } }
     })
-  createLambdaAlarms(disabledFunctionAlarmProperties, testContext, compiledTemplate)
+  createLambdaAlarms(disabledFunctionAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   const alarmResources = getResourcesByType('AWS::CloudWatch::Alarm', compiledTemplate)
   t.equal(Object.keys(alarmResources).length, 0)
@@ -523,7 +523,7 @@ test('Duration alarms are created if no timeout is specified', (t) => {
     delete resource.Properties?.Timeout
   }
 
-  const alarmResources = createLambdaAlarms(FunctionAlarmProperties, testContext, compiledTemplate)
+  const alarmResources = createLambdaAlarms(FunctionAlarmProperties, testAlarmActionsConfig, compiledTemplate)
   const invocAlarmResources = filterObject(
     alarmResources,
     (res) => res.Properties.AlarmName.payload[0].startsWith('Lambda_Duration')
@@ -537,7 +537,7 @@ test('Lambda alarms are not created if the slic watch config does not exist', (t
   const compiledTemplate = createTestCloudFormationTemplate()
   const perLambdaConfig = AlarmProperties
   perLambdaConfig.HelloLambdaFunction = AlarmProperties.Lambda
-  const createdAlarms = createLambdaAlarms(perLambdaConfig, testContext, compiledTemplate)
+  const createdAlarms = createLambdaAlarms(perLambdaConfig, testAlarmActionsConfig, compiledTemplate)
 
   t.same(Object.keys(createdAlarms), ['slicWatchLambdaErrorsAlarmHelloLambdaFunction', 'slicWatchLambdaThrottlesAlarmHelloLambdaFunction', 'slicWatchLambdaDurationAlarmHelloLambdaFunction'])
   t.end()

--- a/core/alarms/tests/sns.test.ts
+++ b/core/alarms/tests/sns.test.ts
@@ -9,7 +9,7 @@ import {
   alarmNameToType,
   createTestConfig,
   createTestCloudFormationTemplate,
-  testContext
+  testAlarmActionsConfig
 } from '../../tests/testing-utils'
 
 test('SNS alarms are created', (t) => {
@@ -33,7 +33,7 @@ test('SNS alarms are created', (t) => {
   const snsAlarmProperties = AlarmProperties.SNS
   const compiledTemplate = createTestCloudFormationTemplate()
 
-  const alarmResources: ResourceType = createSnsAlarms(snsAlarmProperties, testContext, compiledTemplate)
+  const alarmResources: ResourceType = createSnsAlarms(snsAlarmProperties, testAlarmActionsConfig, compiledTemplate)
   const expectedTypes = {
     SNS_NumberOfNotificationsFilteredOutInvalidAttributes_Alarm: 'NumberOfNotificationsFilteredOut-InvalidAttributes',
     SNS_NumberOfNotificationsFailed_Alarm: 'NumberOfNotificationsFailed'
@@ -89,7 +89,7 @@ test('SNS alarms are not created when disabled globally', (t) => {
   )
   const snsAlarmProperties = AlarmProperties.SNS
   const compiledTemplate = createTestCloudFormationTemplate()
-  createSnsAlarms(snsAlarmProperties, testContext, compiledTemplate)
+  createSnsAlarms(snsAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   const alarmResources = getResourcesByType('AWS::CloudWatch::Alarm', compiledTemplate)
 

--- a/core/alarms/tests/sqs.test.ts
+++ b/core/alarms/tests/sqs.test.ts
@@ -9,7 +9,7 @@ import {
   alarmNameToType,
   createTestConfig,
   createTestCloudFormationTemplate,
-  testContext
+  testAlarmActionsConfig
 } from '../../tests/testing-utils'
 
 export interface AlarmsByType {
@@ -39,7 +39,7 @@ test('SQS alarms are created', (t) => {
   const sqsAlarmProperties = AlarmProperties.SQS
   const compiledTemplate = createTestCloudFormationTemplate()
 
-  const alarmResources: ResourceType = createSQSAlarms(sqsAlarmProperties, testContext, compiledTemplate)
+  const alarmResources: ResourceType = createSQSAlarms(sqsAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   // We have 2 queues (a regular one and a fifo one) in our test stack
   // we expect 2 alarms per queue
@@ -178,7 +178,7 @@ test('SQS alarms are not created when disabled globally', (t) => {
     })
   const sqsAlarmProperties = AlarmProperties.SQS
   const compiledTemplate = createTestCloudFormationTemplate()
-  createSQSAlarms(sqsAlarmProperties, testContext, compiledTemplate)
+  createSQSAlarms(sqsAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   const alarmResources = getResourcesByType('AWS::CloudWatch::Alarm', compiledTemplate)
 
@@ -206,7 +206,7 @@ test('SQS alarms are not created when disabled individually', (t) => {
     })
   const sqsAlarmProperties = AlarmProperties.SQS
   const compiledTemplate = createTestCloudFormationTemplate()
-  createSQSAlarms(sqsAlarmProperties, testContext, compiledTemplate)
+  createSQSAlarms(sqsAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   const alarmResources = getResourcesByType('AWS::CloudWatch::Alarm', compiledTemplate)
 
@@ -233,6 +233,6 @@ test('SQS AgeOfOldestMessage alarms throws if misconfigured (enabled but no thre
     })
   const sqsAlarmProperties = AlarmProperties.SQS
   const compiledTemplate = createTestCloudFormationTemplate()
-  t.throws(() => { createSQSAlarms(sqsAlarmProperties, testContext, compiledTemplate) }, { message: 'SQS AgeOfOldestMessage alarm is enabled but `Threshold` is not specified. Please specify a threshold or disable the alarm.' })
+  t.throws(() => { createSQSAlarms(sqsAlarmProperties, testAlarmActionsConfig, compiledTemplate) }, { message: 'SQS AgeOfOldestMessage alarm is enabled but `Threshold` is not specified. Please specify a threshold or disable the alarm.' })
   t.end()
 })

--- a/core/alarms/tests/sqs.test.ts
+++ b/core/alarms/tests/sqs.test.ts
@@ -1,5 +1,5 @@
 import { test } from 'tap'
-
+import type { AlarmProperties } from 'cloudform-types/types/cloudWatch/alarm'
 import createSQSAlarms from '../sqs'
 import { getResourcesByType } from '../../cf-template'
 import type { ResourceType } from '../../cf-template'
@@ -48,7 +48,7 @@ test('SQS alarms are created', (t) => {
   function getAlarmsByType (): AlarmsByType {
     const alarmsByType = {}
     for (const alarmResource of Object.values(alarmResources)) {
-      const al = alarmResource.Properties
+      const al = alarmResource.Properties as AlarmProperties
       assertCommonAlarmProperties(t, al)
       const alarmType = alarmNameToType(al?.AlarmName)
       alarmsByType[alarmType] = alarmsByType[alarmType] ?? new Set()

--- a/core/alarms/tests/step-functions.test.ts
+++ b/core/alarms/tests/step-functions.test.ts
@@ -9,7 +9,7 @@ import {
   alarmNameToType,
   createTestConfig,
   createTestCloudFormationTemplate,
-  testContext
+  testAlarmActionsConfig
 } from '../../tests/testing-utils'
 
 test('Step Function alarms are created', (t) => {
@@ -36,7 +36,7 @@ test('Step Function alarms are created', (t) => {
   )
   const sfAlarmProperties = AlarmProperties.States
   const compiledTemplate = createTestCloudFormationTemplate()
-  const alarmResources: ResourceType = createStatesAlarms(sfAlarmProperties, testContext, compiledTemplate)
+  const alarmResources: ResourceType = createStatesAlarms(sfAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   const alarmsByType = {}
   t.equal(Object.keys(alarmResources).length, 6)
@@ -106,7 +106,7 @@ test('Step function alarms are not created when disabled globally', (t) => {
   )
   const sfAlarmProperties = AlarmProperties.States
   const compiledTemplate = createTestCloudFormationTemplate()
-  createStatesAlarms(sfAlarmProperties, testContext, compiledTemplate)
+  createStatesAlarms(sfAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   const alarmResources = getResourcesByType('AWS::CloudWatch::Alarm', compiledTemplate)
 
@@ -138,7 +138,7 @@ test('Step function alarms are not created when disabled individually', (t) => {
   )
   const sfAlarmProperties = AlarmProperties.States
   const compiledTemplate = createTestCloudFormationTemplate()
-  createStatesAlarms(sfAlarmProperties, testContext, compiledTemplate)
+  createStatesAlarms(sfAlarmProperties, testAlarmActionsConfig, compiledTemplate)
 
   const alarmResources = getResourcesByType('AWS::CloudWatch::Alarm', compiledTemplate)
 

--- a/core/inputs/config-schema.ts
+++ b/core/inputs/config-schema.ts
@@ -1,3 +1,4 @@
+import { type JSONSchema4 } from 'json-schema'
 
 /*
  * Source https://github.com/ajv-validator/ajv-formats/blob/4dd65447575b35d0187c6b125383366969e6267e/src/formats.ts#L113
@@ -5,7 +6,7 @@
 const iso8601Pattern = '^\\d\\d\\d\\d-[0-1]\\d-[0-3]\\d[t\\s](?:[0-2]\\d:[0-5]\\d:[0-5]\\d|23:59:60)(?:\\.\\d+)?(?:z|[+-]\\d\\d(?::?\\d\\d)?)?$'
 const percentilePattern = '^p(\\d{1,2}(\\.\\d{0,2})?|100)$'
 
-const statisticType = {
+const statisticType: JSONSchema4 = {
   type: ['string', 'null'],
   enum: ['Average', 'Maximum', 'Minimum', 'SampleCount', 'Sum']
 }
@@ -40,7 +41,7 @@ const supportedWidgets = {
   AppSync: ['5XXError', '4XXError', 'Latency', 'Requests', 'ConnectServerError', 'DisconnectServerError', 'SubscribeServerError', 'UnsubscribeServerError', 'PublishDataMessageServerError']
 }
 
-const commonAlarmProperties = {
+const commonAlarmProperties: JSONSchema4Properties = {
   enabled: { type: 'boolean' },
   Period: {
     type: ['integer', 'null'],
@@ -80,7 +81,7 @@ const commonAlarmProperties = {
   }
 }
 
-const alarmSchemas = {
+const alarmSchemas: JSONSchema4 = {
   Lambda: {}
 }
 for (const service of Object.keys(supportedAlarms)) {
@@ -102,7 +103,7 @@ for (const service of Object.keys(supportedAlarms)) {
   }
 }
 
-const alarmsSchema = {
+const alarmsSchema: JSONSchema4 = {
   type: 'object',
   properties: {
     ...commonAlarmProperties,
@@ -111,7 +112,9 @@ const alarmsSchema = {
   additionalProperties: false
 }
 
-const commonWidgetProperties = {
+type JSONSchema4Properties = Record<string, JSONSchema4>
+
+const commonWidgetProperties: JSONSchema4Properties = {
   enabled: { type: 'boolean' },
   width: { type: ['integer', 'null'], minimum: 1, maximum: 24 },
   height: { type: ['integer', 'null'], minimum: 1, maximum: 1000 },
@@ -131,9 +134,10 @@ const commonWidgetProperties = {
   }
 }
 
-const widgetSchemas = {
+const widgetSchemas: JSONSchema4 = {
   Lambda: {}
 }
+
 for (const service of Object.keys(supportedWidgets)) {
   widgetSchemas[service] = {
     type: 'object',
@@ -153,7 +157,7 @@ for (const service of Object.keys(supportedWidgets)) {
   }
 }
 
-const dashboardSchema = {
+const dashboardSchema: JSONSchema4 = {
   type: 'object',
   properties: {
     enabled: { type: 'boolean' },
@@ -185,15 +189,25 @@ const dashboardSchema = {
   additionalProperties: false
 }
 
+const resourceRef: JSONSchema4 = { anyOf: [{ type: 'string' }, { type: 'object' }] }
+
 /**
  * JSON Schema for SLIC Watch
  */
-const slicWatchSchema = {
+const slicWatchSchema: JSONSchema4 = {
   type: 'object',
   properties: {
     alarms: alarmsSchema,
     dashboard: dashboardSchema,
-    topicArn: { anyOf: [{ type: 'string' }, { type: 'object' }] },
+    topicArn: resourceRef,
+    alarmActionsConfig: {
+      type: 'object',
+      properties: {
+        alarmActions: { type: 'array', items: resourceRef },
+        okActions: { type: 'array', items: resourceRef },
+        actionsEnabled: { type: 'boolean', default: true }
+      }
+    },
     enabled: { type: 'boolean' }
   },
   required: [],
@@ -203,7 +217,7 @@ const slicWatchSchema = {
 /**
  * JSON Schema for SLIC Watch configuration
  */
-const pluginConfigSchema = {
+const pluginConfigSchema: JSONSchema4 = {
   $schema: 'http://json-schema.org/draft-07/schema',
   title: 'SLIC Watch configuration',
   type: 'object',
@@ -217,7 +231,7 @@ const pluginConfigSchema = {
 /**
  * JSON Schema for the SLIC Watch configuration at an individual function level
  */
-const functionConfigSchema = {
+const functionConfigSchema: JSONSchema4 = {
   $schema: 'http://json-schema.org/draft-07/schema',
   title: 'SLIC Watch function configuration',
   type: 'object',

--- a/core/inputs/default-config.ts
+++ b/core/inputs/default-config.ts
@@ -1,7 +1,7 @@
 import type { SlicWatchCascadedAlarmsConfig, SlicWatchAlarmConfig } from '../alarms/alarm-types'
 import type { SlicWatchDashboardConfig } from '../dashboards/dashboard-types'
 
-interface DefaultConfig {
+export interface DefaultConfig {
   alarms: SlicWatchCascadedAlarmsConfig<SlicWatchAlarmConfig>
   dashboard: SlicWatchDashboardConfig
 }

--- a/core/inputs/general-config.ts
+++ b/core/inputs/general-config.ts
@@ -1,0 +1,67 @@
+import { merge } from 'lodash'
+import Ajv from 'ajv'
+import { type AlarmActionsConfig } from '../alarms/alarm-types'
+import { slicWatchSchema } from './config-schema'
+import { defaultConfig, type DefaultConfig } from './default-config'
+
+export interface SlicWatchConfig {
+  /**
+   * Legacy way to specify the SNS Topic ARN for Alarm actions
+   */
+  topicArn?: string
+  /**
+   * Recommended way to specify the SNS Topic ARN for Alarm and OK status actions
+   */
+  alarmActionsConfig?: AlarmActionsConfig
+  /**
+   * Enable or disable notifications to configured SNS Topics
+   */
+  enabled?: boolean
+}
+
+export interface ResolvedConfiguration extends DefaultConfig, SlicWatchConfig {
+  enabled: boolean
+  alarmActionsConfig: AlarmActionsConfig
+}
+
+export class ConfigError extends Error {
+}
+
+/**
+ * Validates and transforms the user-provided top-configuration for SLIC Watch. The configuration
+ * is validated accoring to the config schema. Defaults are applied where not provided by the user.
+ * Finally, the alarm actions are addded.
+ *
+ * @param slicWatchConfig The user-provided configuration
+ * @returns Resolved configuration
+ */
+export function resolveSlicWatchConfig (slicWatchConfig: SlicWatchConfig): ResolvedConfiguration {
+  const ajv = new Ajv({
+    unicodeRegExp: false
+  })
+  const slicWatchValidate = ajv.compile(slicWatchSchema)
+  const slicWatchValid = slicWatchValidate(slicWatchConfig)
+  if (!slicWatchValid) {
+    throw new ConfigError('SLIC Watch configuration is invalid: ' + ajv.errorsText(slicWatchValidate.errors))
+  }
+
+  // Resolve alarm actions using the older config syntax (topicArn) and the more flexible,
+  // newer syntax (AlarmActionsConfig)
+  const defaultAlarmActions: string[] = []
+  if (slicWatchConfig.topicArn != null && slicWatchConfig.topicArn.length > 0) {
+    defaultAlarmActions.push(slicWatchConfig.topicArn)
+  }
+
+  const alarmActionsConfig: AlarmActionsConfig = {
+    actionsEnabled: slicWatchConfig.alarmActionsConfig?.actionsEnabled ?? true,
+    alarmActions: (slicWatchConfig.alarmActionsConfig?.alarmActions ?? defaultAlarmActions),
+    okActions: slicWatchConfig.alarmActionsConfig?.okActions ?? []
+  }
+
+  const config = merge(defaultConfig, slicWatchConfig)
+  return {
+    enabled: slicWatchConfig.enabled ?? true,
+    ...config,
+    alarmActionsConfig
+  }
+}

--- a/core/inputs/tests/config-schema.test.ts
+++ b/core/inputs/tests/config-schema.test.ts
@@ -7,7 +7,11 @@ import { pluginConfigSchema, slicWatchSchema } from '../config-schema'
 test('Default config conforms to the config schema', (t) => {
   const slicWatchConfig = {
     ...defaultConfig,
-    topicArn: 'dummy-topic-arn'
+    topicArn: 'dummy-topic-arn',
+    alarmActionsConfig: {
+      alarmActions: [],
+      okActions: []
+    }
   }
   const ajv = new Ajv({
     unicodeRegExp: false

--- a/core/inputs/tests/general-config.test.ts
+++ b/core/inputs/tests/general-config.test.ts
@@ -1,0 +1,52 @@
+import { test } from 'tap'
+
+import { type SlicWatchConfig, resolveSlicWatchConfig } from '../general-config'
+
+const topic1 = 'arn:aws:sns::eu-west-1123456789012:MyTopic'
+const topic2 = 'arn:aws:sns::eu-west-1123456789012:MyOtherTopic'
+
+test('Configuration resolves topicArn to alarmActions', (t) => {
+  const slicWatchConfig = { topicArn: topic1, enabled: true }
+
+  const resolvedConfig = resolveSlicWatchConfig(slicWatchConfig)
+  t.same(resolvedConfig.alarmActionsConfig, {
+    alarmActions: [topic1],
+    okActions: [],
+    actionsEnabled: true
+  })
+
+  t.end()
+})
+
+test('Configuration ignores topicArn if alarmActions are set', (t) => {
+  const slicWatchConfig: SlicWatchConfig = {
+    topicArn: topic2,
+    alarmActionsConfig: { alarmActions: [topic1] },
+    enabled: true
+  }
+
+  const resolvedConfig = resolveSlicWatchConfig(slicWatchConfig)
+  t.same(resolvedConfig.alarmActionsConfig, {
+    alarmActions: [topic1],
+    okActions: [],
+    actionsEnabled: true
+  })
+
+  t.end()
+})
+
+test('Configuration includes okActions', (t) => {
+  const slicWatchConfig: SlicWatchConfig = {
+    alarmActionsConfig: { alarmActions: [topic1], okActions: [topic2], actionsEnabled: false },
+    enabled: true
+  }
+
+  const resolvedConfig = resolveSlicWatchConfig(slicWatchConfig)
+  t.same(resolvedConfig.alarmActionsConfig, {
+    alarmActions: [topic1],
+    okActions: [topic2],
+    actionsEnabled: false
+  })
+
+  t.end()
+})

--- a/core/package.json
+++ b/core/package.json
@@ -25,6 +25,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@types/json-schema": "^7.0.14",
     "@types/lodash": "^4.14.191",
     "@types/yaml": "^1.9.7",
     "ajv": "^8.11.0",

--- a/core/tests/testing-utils.ts
+++ b/core/tests/testing-utils.ts
@@ -5,11 +5,12 @@ import { cascade } from '../inputs/cascading-config'
 import _defaultCfTemplate from '../cf-resources/cloudformation-template-stack.json'
 import _albCfTemplate from '../cf-resources/alb-cloudformation-template-stack.json'
 import _appSyncCfTemplate from '../cf-resources/appsync-cloudformation-template-stack.json'
+import { type AlarmActionsConfig } from '../alarms/alarm-types'
 const defaultCfTemplate = _defaultCfTemplate as Template
 const albCfTemplate = _albCfTemplate as Template
 const appSyncCfTemplate = _appSyncCfTemplate as unknown as Template
 
-const testContext = { alarmActions: ['dummy-arn'] }
+const testAlarmActionsConfig: AlarmActionsConfig = { alarmActions: ['dummy-arn'], actionsEnabled: true }
 
 function assertCommonAlarmProperties (t, al) {
   t.ok(al.AlarmDescription)
@@ -49,7 +50,7 @@ export {
   albCfTemplate,
   appSyncCfTemplate,
   defaultCfTemplate,
-  testContext,
+  testAlarmActionsConfig,
   assertCommonAlarmProperties,
   alarmNameToType,
   createTestConfig,

--- a/core/tests/testing-utils.ts
+++ b/core/tests/testing-utils.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import type Template from 'cloudform-types/types/template'
+import type { AlarmProperties } from 'cloudform-types/types/cloudWatch/alarm'
 
 import { cascade } from '../inputs/cascading-config'
 import _defaultCfTemplate from '../cf-resources/cloudformation-template-stack.json'
@@ -10,13 +11,15 @@ const defaultCfTemplate = _defaultCfTemplate as Template
 const albCfTemplate = _albCfTemplate as Template
 const appSyncCfTemplate = _appSyncCfTemplate as unknown as Template
 
-const testAlarmActionsConfig: AlarmActionsConfig = { alarmActions: ['dummy-arn'], actionsEnabled: true }
+const testAlarmActionsConfig: AlarmActionsConfig = { alarmActions: ['dummy-arn'], okActions: ['dummy-arn-2'], actionsEnabled: true }
 
-function assertCommonAlarmProperties (t, al) {
+function assertCommonAlarmProperties (t, al: AlarmProperties) {
   t.ok(al.AlarmDescription)
   t.ok(al.ActionsEnabled)
-  t.equal(al.AlarmActions.length, 1)
   t.ok(al.AlarmActions)
+  t.equal((al.AlarmActions as string[]).length, 1)
+  t.ok(al.OKActions)
+  t.equal((al.OKActions as string[]).length, 1)
   t.ok(al.ComparisonOperator)
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
       "version": "3.0.0",
       "license": "ISC",
       "dependencies": {
+        "@types/json-schema": "^7.0.14",
         "@types/lodash": "^4.14.191",
         "@types/yaml": "^1.9.7",
         "ajv": "^8.11.0",
@@ -3672,9 +3673,9 @@
       "dev": true
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.11",
-      "dev": true,
-      "license": "MIT"
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.14.tgz",
+      "integrity": "sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -16518,8 +16519,9 @@
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.11",
-      "dev": true
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.14.tgz",
+      "integrity": "sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw=="
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -22157,6 +22159,7 @@
     "slic-watch-core": {
       "version": "file:core",
       "requires": {
+        "@types/json-schema": "^7.0.14",
         "@types/lodash": "^4.14.191",
         "@types/yaml": "^1.9.7",
         "ajv": "^8.11.0",

--- a/sam-test-project/template.yaml
+++ b/sam-test-project/template.yaml
@@ -9,8 +9,11 @@ Transform:
 Metadata:
   slicWatch:
     enabled: true
-    # topicArn: ${env:ALARM_TOPIC}
-    topicArn: !Ref MonitoringTopic
+    alarmActionsConfig: {
+      alarmActions: [!Ref MonitoringTopic],
+      okActions: [!Ref MonitoringTopic],
+      actionsEnabled: true
+    }
     alarms:
       Lambda:
         Invocations:

--- a/serverless-plugin/package.json
+++ b/serverless-plugin/package.json
@@ -9,7 +9,7 @@
     "directory": "serverless-plugin"
   },
   "scripts": {
-    "test": "tap --coverage-report=html --no-browser --no-check-coverage tests/**/*.test.ts",
+    "test": "tap --include='**/tests/**/*.ts' --coverage-report=lcovonly --allow-incomplete-coverage",
     "prepublish": "cp ../README.md README.md",
     "build": "esbuild index.ts --outdir=dist --bundle --format=cjs --platform=node --sourcemap",
     "watch": "npm run build -- --watch"

--- a/serverless-plugin/tests/index.test.ts
+++ b/serverless-plugin/tests/index.test.ts
@@ -161,6 +161,7 @@ test('index', t => {
   t.test('Plugin execution succeeds if no SNS Topic is provided', t => {
     const serviceYmlWithoutTopic = _.cloneDeep(slsYaml)
     delete serviceYmlWithoutTopic.custom.slicWatch.topicArn
+    delete serviceYmlWithoutTopic.custom.slicWatch.alarmActionsConfig
     const plugin = new ServerlessPlugin({
       ...mockServerless,
       service: {

--- a/serverless-test-project-alb/serverless.yml
+++ b/serverless-test-project-alb/serverless.yml
@@ -16,7 +16,9 @@ custom:
     - Key: Stage
       Value: ${self:provider.stage}
   slicWatch:
-    topicArn: ${env:ALARM_TOPIC}
+    alarmActionsConfig:
+      alarmActions:
+        - ${env:ALARM_TOPIC}
     alarms:
       Lambda:
         Invocations:

--- a/serverless-test-project-appsync/serverless.yml
+++ b/serverless-test-project-appsync/serverless.yml
@@ -21,7 +21,9 @@ custom:
   appSync:
     - ${file(serverless.appsync-api.yml)}
   slicWatch:
-    topicArn: ${env:ALARM_TOPIC}
+    alarmActionsConfig:
+      alarmActions: 
+        - ${env:ALARM_TOPIC}
     alarms:
       Lambda:
         Invocations:

--- a/serverless-test-project/serverless.yml
+++ b/serverless-test-project/serverless.yml
@@ -8,7 +8,12 @@ plugins:
   - serverless-slic-watch-plugin
 custom:
   slicWatch:
-    topicArn: ${env:ALARM_TOPIC}
+    alarmActionsConfig:
+      alarmActions: 
+        - ${env:ALARM_TOPIC}
+      okActions:
+        - ${env:ALARM_TOPIC}
+      actionsEnabled: true
     alarms:
       Lambda:
         Invocations:


### PR DESCRIPTION
This PR replaces #85 since the codebase has change significantly since

Add ok actions to notify if alarm is resolved.

## Description
Resolves #84 

## Motivation and Context
CloudWatch Alarms support notifications to the same or other/additional topics when the alarm is resolved (`ALARM -> OK`). To date, SLIC Watch did not support this, only `OK -> ALARM`

## How Has This Been Tested?
- `npm t`
- Deployment and manual validation of test projets

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
