### PR TITLE
feat(tests): add snapshot tests for all test projects

### DIFF
--- a/cdk-test-project/.eslintrc.js
+++ b/cdk-test-project/.eslintrc.js
@@ -1,20 +1,5 @@
 module.exports = {
-  root: true,
-  env: {
-    node: true
-  },
-  plugins: [
-    '@typescript-eslint'
-  ],
-  parserOptions: {
-    project: './tsconfig.json',
-    tsconfigRootDir: __dirname,
-    ecmaVersion: 2018
-  },
   rules: {
     'no-new': 0
-  },
-  extends: [
-    'standard-with-typescript'
-  ]
+  }
 }

--- a/cdk-test-project/tests/snapshot/cdk-test-project-snapshot.test.ts
+++ b/cdk-test-project/tests/snapshot/cdk-test-project-snapshot.test.ts
@@ -1,0 +1,26 @@
+import { test } from 'tap'
+import type { Template } from 'cloudform'
+import { handler } from 'cf-macro-slic-watch/index'
+
+import generalEuStack from './fixtures/CdkGeneralStackTest-Europe.template.json'
+import generalUsStack from './fixtures/CdkGeneralStackTest-US.template.json'
+import ecsStack from './fixtures/CdkECSStackTest-Europe.template.json'
+import stepFunctionStack from './fixtures/CdkSFNStackTest-Europe.template.json'
+
+const stacks = {
+  generalEuStack,
+  generalUsStack,
+  ecsStack,
+  stepFunctionStack
+}
+
+test('cdk-test-project snapshot', async (t) => {
+  for (const [name, stack] of Object.entries(stacks)) {
+    const response = await handler({ fragment: stack as Template, requestId: 'snapshot-test' })
+    t.notOk(response.errorMessage)
+    t.equal(response.status, 'success')
+    t.equal(response.requestId, 'snapshot-test')
+    t.matchSnapshot(response.fragment, `${name} fragment`)
+  }
+  t.end()
+})

--- a/cdk-test-project/tests/snapshot/fixtures/CdkECSStackTest-Europe.template.json
+++ b/cdk-test-project/tests/snapshot/fixtures/CdkECSStackTest-Europe.template.json
@@ -1,0 +1,923 @@
+{
+ "Transform": "SlicWatch-v3",
+ "Metadata": {
+  "slicWatch": {
+   "enabled": true,
+   "alarms": {
+    "Lambda": {
+     "Invocations": {
+      "enabled": true,
+      "Threshold": 10
+     }
+    },
+    "SQS": {
+     "AgeOfOldestMessage": {
+      "Statistic": "Maximum",
+      "enabled": true,
+      "Threshold": 60
+     },
+     "InFlightMessagesPc": {
+      "Statistic": "Maximum",
+      "Threshold": 1
+     }
+    }
+   }
+  }
+ },
+ "Resources": {
+  "MyWebServerLB3B5FD3AB": {
+   "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+   "Properties": {
+    "LoadBalancerAttributes": [
+     {
+      "Key": "deletion_protection.enabled",
+      "Value": "false"
+     }
+    ],
+    "Scheme": "internet-facing",
+    "SecurityGroups": [
+     {
+      "Fn::GetAtt": [
+       "MyWebServerLBSecurityGroup01B285AA",
+       "GroupId"
+      ]
+     }
+    ],
+    "Subnets": [
+     {
+      "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1Subnet3C273B99"
+     },
+     {
+      "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2Subnet95FF715A"
+     }
+    ],
+    "Type": "application"
+   },
+   "DependsOn": [
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1DefaultRouteFF4E2178",
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1RouteTableAssociation8B583A17",
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2DefaultRouteB1375520",
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2RouteTableAssociation43E5803C"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/LB/Resource"
+   }
+  },
+  "MyWebServerLBSecurityGroup01B285AA": {
+   "Type": "AWS::EC2::SecurityGroup",
+   "Properties": {
+    "GroupDescription": "Automatically created Security Group for ELB CdkECSStackTestEuropeMyWebServerLBE298D4B6",
+    "SecurityGroupIngress": [
+     {
+      "CidrIp": "0.0.0.0/0",
+      "Description": "Allow from anyone on port 80",
+      "FromPort": 80,
+      "IpProtocol": "tcp",
+      "ToPort": 80
+     }
+    ],
+    "VpcId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/LB/SecurityGroup/Resource"
+   }
+  },
+  "MyWebServerLBSecurityGrouptoCdkECSStackTestEuropeMyWebServerServiceSecurityGroup792A2ECD807CF0A9FB": {
+   "Type": "AWS::EC2::SecurityGroupEgress",
+   "Properties": {
+    "GroupId": {
+     "Fn::GetAtt": [
+      "MyWebServerLBSecurityGroup01B285AA",
+      "GroupId"
+     ]
+    },
+    "IpProtocol": "tcp",
+    "Description": "Load balancer to target",
+    "DestinationSecurityGroupId": {
+     "Fn::GetAtt": [
+      "MyWebServerServiceSecurityGroup6788214A",
+      "GroupId"
+     ]
+    },
+    "FromPort": 80,
+    "ToPort": 80
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/LB/SecurityGroup/to CdkECSStackTestEuropeMyWebServerServiceSecurityGroup792A2ECD:80"
+   }
+  },
+  "MyWebServerLBPublicListener03D7C493": {
+   "Type": "AWS::ElasticLoadBalancingV2::Listener",
+   "Properties": {
+    "DefaultActions": [
+     {
+      "TargetGroupArn": {
+       "Ref": "MyWebServerLBPublicListenerECSGroup5AB9F1C3"
+      },
+      "Type": "forward"
+     }
+    ],
+    "LoadBalancerArn": {
+     "Ref": "MyWebServerLB3B5FD3AB"
+    },
+    "Port": 80,
+    "Protocol": "HTTP"
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/LB/PublicListener/Resource"
+   }
+  },
+  "MyWebServerLBPublicListenerECSGroup5AB9F1C3": {
+   "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+   "Properties": {
+    "Port": 80,
+    "Protocol": "HTTP",
+    "TargetGroupAttributes": [
+     {
+      "Key": "stickiness.enabled",
+      "Value": "false"
+     }
+    ],
+    "TargetType": "ip",
+    "VpcId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/LB/PublicListener/ECSGroup/Resource"
+   }
+  },
+  "MyWebServerTaskDefTaskRoleB23C17AA": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/TaskDef/TaskRole/Resource"
+   }
+  },
+  "MyWebServerTaskDef4CE825A0": {
+   "Type": "AWS::ECS::TaskDefinition",
+   "Properties": {
+    "ContainerDefinitions": [
+     {
+      "Essential": true,
+      "Image": "amazon/amazon-ecs-sample",
+      "LogConfiguration": {
+       "LogDriver": "awslogs",
+       "Options": {
+        "awslogs-group": {
+         "Ref": "MyWebServerTaskDefwebLogGroupC6EE23D4"
+        },
+        "awslogs-stream-prefix": "MyWebServer",
+        "awslogs-region": "eu-west-1"
+       }
+      },
+      "Name": "web",
+      "PortMappings": [
+       {
+        "ContainerPort": 80,
+        "Protocol": "tcp"
+       }
+      ]
+     }
+    ],
+    "Cpu": "256",
+    "ExecutionRoleArn": {
+     "Fn::GetAtt": [
+      "MyWebServerTaskDefExecutionRole3C69E361",
+      "Arn"
+     ]
+    },
+    "Family": "CdkECSStackTestEuropeMyWebServerTaskDef979012A1",
+    "Memory": "512",
+    "NetworkMode": "awsvpc",
+    "RequiresCompatibilities": [
+     "FARGATE"
+    ],
+    "TaskRoleArn": {
+     "Fn::GetAtt": [
+      "MyWebServerTaskDefTaskRoleB23C17AA",
+      "Arn"
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/TaskDef/Resource"
+   }
+  },
+  "MyWebServerTaskDefwebLogGroupC6EE23D4": {
+   "Type": "AWS::Logs::LogGroup",
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/TaskDef/web/LogGroup/Resource"
+   }
+  },
+  "MyWebServerTaskDefExecutionRole3C69E361": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/TaskDef/ExecutionRole/Resource"
+   }
+  },
+  "MyWebServerTaskDefExecutionRoleDefaultPolicy2AEB4329": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::GetAtt": [
+         "MyWebServerTaskDefwebLogGroupC6EE23D4",
+         "Arn"
+        ]
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "MyWebServerTaskDefExecutionRoleDefaultPolicy2AEB4329",
+    "Roles": [
+     {
+      "Ref": "MyWebServerTaskDefExecutionRole3C69E361"
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/TaskDef/ExecutionRole/DefaultPolicy/Resource"
+   }
+  },
+  "MyWebServerService2FE7341D": {
+   "Type": "AWS::ECS::Service",
+   "Properties": {
+    "Cluster": {
+     "Ref": "EcsDefaultClusterMnL3mNNYN926A5246"
+    },
+    "DeploymentConfiguration": {
+     "MaximumPercent": 200,
+     "MinimumHealthyPercent": 50
+    },
+    "EnableECSManagedTags": false,
+    "HealthCheckGracePeriodSeconds": 60,
+    "LaunchType": "FARGATE",
+    "LoadBalancers": [
+     {
+      "ContainerName": "web",
+      "ContainerPort": 80,
+      "TargetGroupArn": {
+       "Ref": "MyWebServerLBPublicListenerECSGroup5AB9F1C3"
+      }
+     }
+    ],
+    "NetworkConfiguration": {
+     "AwsvpcConfiguration": {
+      "AssignPublicIp": "DISABLED",
+      "SecurityGroups": [
+       {
+        "Fn::GetAtt": [
+         "MyWebServerServiceSecurityGroup6788214A",
+         "GroupId"
+        ]
+       }
+      ],
+      "Subnets": [
+       {
+        "Ref": "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet1Subnet075EFF4C"
+       },
+       {
+        "Ref": "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet2SubnetE4CEDF73"
+       }
+      ]
+     }
+    },
+    "TaskDefinition": {
+     "Ref": "MyWebServerTaskDef4CE825A0"
+    }
+   },
+   "DependsOn": [
+    "MyWebServerLBPublicListenerECSGroup5AB9F1C3",
+    "MyWebServerLBPublicListener03D7C493",
+    "MyWebServerTaskDefTaskRoleB23C17AA"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/Service/Service"
+   }
+  },
+  "MyWebServerServiceSecurityGroup6788214A": {
+   "Type": "AWS::EC2::SecurityGroup",
+   "Properties": {
+    "GroupDescription": "CdkECSStackTest-Europe/MyWebServer/Service/SecurityGroup",
+    "SecurityGroupEgress": [
+     {
+      "CidrIp": "0.0.0.0/0",
+      "Description": "Allow all outbound traffic by default",
+      "IpProtocol": "-1"
+     }
+    ],
+    "VpcId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521"
+    }
+   },
+   "DependsOn": [
+    "MyWebServerTaskDefTaskRoleB23C17AA"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/Service/SecurityGroup/Resource"
+   }
+  },
+  "MyWebServerServiceSecurityGroupfromCdkECSStackTestEuropeMyWebServerLBSecurityGroup8823910380E44CF71E": {
+   "Type": "AWS::EC2::SecurityGroupIngress",
+   "Properties": {
+    "IpProtocol": "tcp",
+    "Description": "Load balancer to target",
+    "FromPort": 80,
+    "GroupId": {
+     "Fn::GetAtt": [
+      "MyWebServerServiceSecurityGroup6788214A",
+      "GroupId"
+     ]
+    },
+    "SourceSecurityGroupId": {
+     "Fn::GetAtt": [
+      "MyWebServerLBSecurityGroup01B285AA",
+      "GroupId"
+     ]
+    },
+    "ToPort": 80
+   },
+   "DependsOn": [
+    "MyWebServerTaskDefTaskRoleB23C17AA"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/Service/SecurityGroup/from CdkECSStackTestEuropeMyWebServerLBSecurityGroup88239103:80"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYN926A5246": {
+   "Type": "AWS::ECS::Cluster",
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Resource"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpc7788A521": {
+   "Type": "AWS::EC2::VPC",
+   "Properties": {
+    "CidrBlock": "10.0.0.0/16",
+    "EnableDnsHostnames": true,
+    "EnableDnsSupport": true,
+    "InstanceTenancy": "default",
+    "Tags": [
+     {
+      "Key": "Name",
+      "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc"
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/Resource"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1Subnet3C273B99": {
+   "Type": "AWS::EC2::Subnet",
+   "Properties": {
+    "VpcId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521"
+    },
+    "AvailabilityZone": {
+     "Fn::Select": [
+      0,
+      {
+       "Fn::GetAZs": ""
+      }
+     ]
+    },
+    "CidrBlock": "10.0.0.0/18",
+    "MapPublicIpOnLaunch": true,
+    "Tags": [
+     {
+      "Key": "aws-cdk:subnet-name",
+      "Value": "Public"
+     },
+     {
+      "Key": "aws-cdk:subnet-type",
+      "Value": "Public"
+     },
+     {
+      "Key": "Name",
+      "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1"
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1/Subnet"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1RouteTableA1FD6ACC": {
+   "Type": "AWS::EC2::RouteTable",
+   "Properties": {
+    "VpcId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521"
+    },
+    "Tags": [
+     {
+      "Key": "Name",
+      "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1"
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1/RouteTable"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1RouteTableAssociation8B583A17": {
+   "Type": "AWS::EC2::SubnetRouteTableAssociation",
+   "Properties": {
+    "RouteTableId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1RouteTableA1FD6ACC"
+    },
+    "SubnetId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1Subnet3C273B99"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1/RouteTableAssociation"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1DefaultRouteFF4E2178": {
+   "Type": "AWS::EC2::Route",
+   "Properties": {
+    "RouteTableId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1RouteTableA1FD6ACC"
+    },
+    "DestinationCidrBlock": "0.0.0.0/0",
+    "GatewayId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpcIGW9C2C2B8F"
+    }
+   },
+   "DependsOn": [
+    "EcsDefaultClusterMnL3mNNYNVpcVPCGW2447264E"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1/DefaultRoute"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1EIP8704DB2F": {
+   "Type": "AWS::EC2::EIP",
+   "Properties": {
+    "Domain": "vpc",
+    "Tags": [
+     {
+      "Key": "Name",
+      "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1"
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1/EIP"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1NATGateway5E3732C1": {
+   "Type": "AWS::EC2::NatGateway",
+   "Properties": {
+    "SubnetId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1Subnet3C273B99"
+    },
+    "AllocationId": {
+     "Fn::GetAtt": [
+      "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1EIP8704DB2F",
+      "AllocationId"
+     ]
+    },
+    "Tags": [
+     {
+      "Key": "Name",
+      "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1"
+     }
+    ]
+   },
+   "DependsOn": [
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1DefaultRouteFF4E2178",
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1RouteTableAssociation8B583A17"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1/NATGateway"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2Subnet95FF715A": {
+   "Type": "AWS::EC2::Subnet",
+   "Properties": {
+    "VpcId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521"
+    },
+    "AvailabilityZone": {
+     "Fn::Select": [
+      1,
+      {
+       "Fn::GetAZs": ""
+      }
+     ]
+    },
+    "CidrBlock": "10.0.64.0/18",
+    "MapPublicIpOnLaunch": true,
+    "Tags": [
+     {
+      "Key": "aws-cdk:subnet-name",
+      "Value": "Public"
+     },
+     {
+      "Key": "aws-cdk:subnet-type",
+      "Value": "Public"
+     },
+     {
+      "Key": "Name",
+      "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2"
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2/Subnet"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2RouteTable263DEAA5": {
+   "Type": "AWS::EC2::RouteTable",
+   "Properties": {
+    "VpcId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521"
+    },
+    "Tags": [
+     {
+      "Key": "Name",
+      "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2"
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2/RouteTable"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2RouteTableAssociation43E5803C": {
+   "Type": "AWS::EC2::SubnetRouteTableAssociation",
+   "Properties": {
+    "RouteTableId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2RouteTable263DEAA5"
+    },
+    "SubnetId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2Subnet95FF715A"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2/RouteTableAssociation"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2DefaultRouteB1375520": {
+   "Type": "AWS::EC2::Route",
+   "Properties": {
+    "RouteTableId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2RouteTable263DEAA5"
+    },
+    "DestinationCidrBlock": "0.0.0.0/0",
+    "GatewayId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpcIGW9C2C2B8F"
+    }
+   },
+   "DependsOn": [
+    "EcsDefaultClusterMnL3mNNYNVpcVPCGW2447264E"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2/DefaultRoute"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2EIPF0764873": {
+   "Type": "AWS::EC2::EIP",
+   "Properties": {
+    "Domain": "vpc",
+    "Tags": [
+     {
+      "Key": "Name",
+      "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2"
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2/EIP"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2NATGateway4C855E00": {
+   "Type": "AWS::EC2::NatGateway",
+   "Properties": {
+    "SubnetId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2Subnet95FF715A"
+    },
+    "AllocationId": {
+     "Fn::GetAtt": [
+      "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2EIPF0764873",
+      "AllocationId"
+     ]
+    },
+    "Tags": [
+     {
+      "Key": "Name",
+      "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2"
+     }
+    ]
+   },
+   "DependsOn": [
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2DefaultRouteB1375520",
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2RouteTableAssociation43E5803C"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2/NATGateway"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet1Subnet075EFF4C": {
+   "Type": "AWS::EC2::Subnet",
+   "Properties": {
+    "VpcId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521"
+    },
+    "AvailabilityZone": {
+     "Fn::Select": [
+      0,
+      {
+       "Fn::GetAZs": ""
+      }
+     ]
+    },
+    "CidrBlock": "10.0.128.0/18",
+    "MapPublicIpOnLaunch": false,
+    "Tags": [
+     {
+      "Key": "aws-cdk:subnet-name",
+      "Value": "Private"
+     },
+     {
+      "Key": "aws-cdk:subnet-type",
+      "Value": "Private"
+     },
+     {
+      "Key": "Name",
+      "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet1"
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet1/Subnet"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet1RouteTable4F1D2E36": {
+   "Type": "AWS::EC2::RouteTable",
+   "Properties": {
+    "VpcId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521"
+    },
+    "Tags": [
+     {
+      "Key": "Name",
+      "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet1"
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet1/RouteTable"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet1RouteTableAssociation34B92275": {
+   "Type": "AWS::EC2::SubnetRouteTableAssociation",
+   "Properties": {
+    "RouteTableId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet1RouteTable4F1D2E36"
+    },
+    "SubnetId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet1Subnet075EFF4C"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet1/RouteTableAssociation"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet1DefaultRouteA5ADF694": {
+   "Type": "AWS::EC2::Route",
+   "Properties": {
+    "RouteTableId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet1RouteTable4F1D2E36"
+    },
+    "DestinationCidrBlock": "0.0.0.0/0",
+    "NatGatewayId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1NATGateway5E3732C1"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet1/DefaultRoute"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet2SubnetE4CEDF73": {
+   "Type": "AWS::EC2::Subnet",
+   "Properties": {
+    "VpcId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521"
+    },
+    "AvailabilityZone": {
+     "Fn::Select": [
+      1,
+      {
+       "Fn::GetAZs": ""
+      }
+     ]
+    },
+    "CidrBlock": "10.0.192.0/18",
+    "MapPublicIpOnLaunch": false,
+    "Tags": [
+     {
+      "Key": "aws-cdk:subnet-name",
+      "Value": "Private"
+     },
+     {
+      "Key": "aws-cdk:subnet-type",
+      "Value": "Private"
+     },
+     {
+      "Key": "Name",
+      "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet2"
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet2/Subnet"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet2RouteTableDCE46591": {
+   "Type": "AWS::EC2::RouteTable",
+   "Properties": {
+    "VpcId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521"
+    },
+    "Tags": [
+     {
+      "Key": "Name",
+      "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet2"
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet2/RouteTable"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet2RouteTableAssociation111C622F": {
+   "Type": "AWS::EC2::SubnetRouteTableAssociation",
+   "Properties": {
+    "RouteTableId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet2RouteTableDCE46591"
+    },
+    "SubnetId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet2SubnetE4CEDF73"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet2/RouteTableAssociation"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet2DefaultRoute20CE2D89": {
+   "Type": "AWS::EC2::Route",
+   "Properties": {
+    "RouteTableId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet2RouteTableDCE46591"
+    },
+    "DestinationCidrBlock": "0.0.0.0/0",
+    "NatGatewayId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2NATGateway4C855E00"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet2/DefaultRoute"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcIGW9C2C2B8F": {
+   "Type": "AWS::EC2::InternetGateway",
+   "Properties": {
+    "Tags": [
+     {
+      "Key": "Name",
+      "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc"
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/IGW"
+   }
+  },
+  "EcsDefaultClusterMnL3mNNYNVpcVPCGW2447264E": {
+   "Type": "AWS::EC2::VPCGatewayAttachment",
+   "Properties": {
+    "VpcId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521"
+    },
+    "InternetGatewayId": {
+     "Ref": "EcsDefaultClusterMnL3mNNYNVpcIGW9C2C2B8F"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/VPCGW"
+   }
+  },
+  "CDKMetadata": {
+   "Type": "AWS::CDK::Metadata",
+   "Properties": {
+    "Analytics": "v2:deflate64:H4sIAAAAAAAA/31Ry27CMBD8Fu7GbTlUXCmlCAm1UYK4IsfZpgvBjux1EIry73WepLSqFGlnx+PsembG58/8cSIudiqT0zTDmJcRCXlinjqUIO0hF0RglOWLPM9QCkKttlokLyITSkLyJkwqCCIwBUpgkAlLKDOviBsFqrSY8fLv24YtP3/2Yx1aAtVpejw63/nJQGujXV5LRm3FQPqZEUhnkK6D5H9ilRqw9he9US2/z2V9tg+WLHCxXyJysQJq9AMKtSPYiTiDG3/jFtZqic3yg7gGq01Ql3dBa2/lRVxZYLCoXR1+vFF1CjAI2k26bkE+s68zKKpfbnnZhbIT9vQKn6iwH3nPaEUCva8j7i7Qxo4OZs6n0OTRwYqhOPMy1O17mxpo702zYIsqlunU77TV6eB7j6uq7j4c5Y5YCFY7047sccWUToAf7UPxNOf+m02OFnFqnCI8Aw/b+g3+NWTOyAIAAA=="
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkECSStackTest-Europe/CDKMetadata/Default"
+   }
+  }
+ },
+ "Outputs": {
+  "MyWebServerLoadBalancerDNSD1AFCC81": {
+   "Value": {
+    "Fn::GetAtt": [
+     "MyWebServerLB3B5FD3AB",
+     "DNSName"
+    ]
+   }
+  },
+  "MyWebServerServiceURLB0ED50F6": {
+   "Value": {
+    "Fn::Join": [
+     "",
+     [
+      "http://",
+      {
+       "Fn::GetAtt": [
+        "MyWebServerLB3B5FD3AB",
+        "DNSName"
+       ]
+      }
+     ]
+    ]
+   }
+  }
+ },
+ "Parameters": {
+  "BootstrapVersion": {
+   "Type": "AWS::SSM::Parameter::Value<String>",
+   "Default": "/cdk-bootstrap/hnb659fds/version",
+   "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]"
+  }
+ },
+ "Rules": {
+  "CheckBootstrapVersion": {
+   "Assertions": [
+    {
+     "Assert": {
+      "Fn::Not": [
+       {
+        "Fn::Contains": [
+         [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5"
+         ],
+         {
+          "Ref": "BootstrapVersion"
+         }
+        ]
+       }
+      ]
+     },
+     "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI."
+    }
+   ]
+  }
+ }
+}

--- a/cdk-test-project/tests/snapshot/fixtures/CdkGeneralStackTest-Europe.template.json
+++ b/cdk-test-project/tests/snapshot/fixtures/CdkGeneralStackTest-Europe.template.json
@@ -1,0 +1,971 @@
+{
+ "Transform": "SlicWatch-v3",
+ "Metadata": {
+  "slicWatch": {
+   "enabled": true,
+   "topicArn": "arn:aws:xxxxxx:mytopic",
+   "alarms": {
+    "Lambda": {
+     "Invocations": {
+      "enabled": true,
+      "Threshold": 10
+     }
+    },
+    "SQS": {
+     "AgeOfOldestMessage": {
+      "Statistic": "Maximum",
+      "enabled": true,
+      "Threshold": 60
+     },
+     "InFlightMessagesPc": {
+      "Statistic": "Maximum",
+      "Threshold": 1
+     }
+    }
+   },
+   "alarmActionsConfig": {
+    "alarmActions": [
+     {
+      "Ref": "MyTopic86869434"
+     }
+    ]
+   }
+  }
+ },
+ "Resources": {
+  "MyTopic86869434": {
+   "Type": "AWS::SNS::Topic",
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/MyTopic/Resource"
+   }
+  },
+  "HelloHandlerServiceRole11EF7C63": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/HelloHandler/ServiceRole/Resource"
+   }
+  },
+  "HelloHandler2E4FBA4D": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": {
+      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-1"
+     },
+     "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "HelloHandlerServiceRole11EF7C63",
+      "Arn"
+     ]
+    },
+    "Handler": "hello.handler",
+    "Runtime": "nodejs18.x"
+   },
+   "DependsOn": [
+    "HelloHandlerServiceRole11EF7C63"
+   ],
+   "Metadata": {
+    "slicWatch": {
+     "alarms": {
+      "Lambda": {
+       "Invocations": {
+        "Threshold": 4
+       }
+      }
+     }
+    }
+   }
+  },
+  "PingHandlerServiceRole46086423": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/PingHandler/ServiceRole/Resource"
+   }
+  },
+  "PingHandler50068074": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": {
+      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-1"
+     },
+     "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "PingHandlerServiceRole46086423",
+      "Arn"
+     ]
+    },
+    "Handler": "hello.handler",
+    "Runtime": "nodejs18.x"
+   },
+   "DependsOn": [
+    "PingHandlerServiceRole46086423"
+   ],
+   "Metadata": {
+    "slicWatch": {
+     "dashboard": {
+      "enabled": false
+     }
+    }
+   }
+  },
+  "ThrottlerHandlerServiceRoleA0481DAF": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/ThrottlerHandler/ServiceRole/Resource"
+   }
+  },
+  "ThrottlerHandler750A7C89": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": {
+      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-1"
+     },
+     "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "ThrottlerHandlerServiceRoleA0481DAF",
+      "Arn"
+     ]
+    },
+    "Handler": "hello.handler",
+    "ReservedConcurrentExecutions": 0,
+    "Runtime": "nodejs18.x"
+   },
+   "DependsOn": [
+    "ThrottlerHandlerServiceRoleA0481DAF"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/ThrottlerHandler/Resource",
+    "aws:asset:path": "asset.03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640",
+    "aws:asset:is-bundled": false,
+    "aws:asset:property": "Code"
+   }
+  },
+  "DriveStreamHandlerServiceRoleD2BAFDD4": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/DriveStreamHandler/ServiceRole/Resource"
+   }
+  },
+  "DriveStreamHandler62F1767B": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": {
+      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-1"
+     },
+     "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "DriveStreamHandlerServiceRoleD2BAFDD4",
+      "Arn"
+     ]
+    },
+    "Handler": "stream-test-handler.handleDrive",
+    "Runtime": "nodejs18.x"
+   },
+   "DependsOn": [
+    "DriveStreamHandlerServiceRoleD2BAFDD4"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/DriveStreamHandler/Resource",
+    "aws:asset:path": "asset.03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640",
+    "aws:asset:is-bundled": false,
+    "aws:asset:property": "Code"
+   }
+  },
+  "DriveQueueHandlerServiceRoleD796850A": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/DriveQueueHandler/ServiceRole/Resource"
+   }
+  },
+  "DriveQueueHandler9F657A00": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": {
+      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-1"
+     },
+     "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "DriveQueueHandlerServiceRoleD796850A",
+      "Arn"
+     ]
+    },
+    "Handler": "hello.handler",
+    "Runtime": "nodejs18.x"
+   },
+   "DependsOn": [
+    "DriveQueueHandlerServiceRoleD796850A"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/DriveQueueHandler/Resource",
+    "aws:asset:path": "asset.03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640",
+    "aws:asset:is-bundled": false,
+    "aws:asset:property": "Code"
+   }
+  },
+  "DriveTableHandlerServiceRoleDDA3FBE1": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/DriveTableHandler/ServiceRole/Resource"
+   }
+  },
+  "DriveTableHandler119966B0": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": {
+      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-1"
+     },
+     "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "DriveTableHandlerServiceRoleDDA3FBE1",
+      "Arn"
+     ]
+    },
+    "Handler": "hello.handler",
+    "Runtime": "nodejs18.x"
+   },
+   "DependsOn": [
+    "DriveTableHandlerServiceRoleDDA3FBE1"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/DriveTableHandler/Resource",
+    "aws:asset:path": "asset.03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640",
+    "aws:asset:is-bundled": false,
+    "aws:asset:property": "Code"
+   }
+  },
+  "myapi162F20B8": {
+   "Type": "AWS::ApiGateway::RestApi",
+   "Properties": {
+    "Name": "myapi"
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Resource"
+   }
+  },
+  "myapiCloudWatchRoleEB425128": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "apigateway.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+       ]
+      ]
+     }
+    ]
+   },
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/CloudWatchRole/Resource"
+   }
+  },
+  "myapiAccountC3A4750C": {
+   "Type": "AWS::ApiGateway::Account",
+   "Properties": {
+    "CloudWatchRoleArn": {
+     "Fn::GetAtt": [
+      "myapiCloudWatchRoleEB425128",
+      "Arn"
+     ]
+    }
+   },
+   "DependsOn": [
+    "myapi162F20B8"
+   ],
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Account"
+   }
+  },
+  "myapiDeploymentB7EF8EB76dbd4bbbb18c5c458967fb55792b4830": {
+   "Type": "AWS::ApiGateway::Deployment",
+   "Properties": {
+    "RestApiId": {
+     "Ref": "myapi162F20B8"
+    },
+    "Description": "Automatically created by the RestApi construct"
+   },
+   "DependsOn": [
+    "myapiproxyANYDD7FCE64",
+    "myapiproxyB6DF4575",
+    "myapiANY111D56B7"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Deployment/Resource"
+   }
+  },
+  "myapiDeploymentStageprod329F21FF": {
+   "Type": "AWS::ApiGateway::Stage",
+   "Properties": {
+    "RestApiId": {
+     "Ref": "myapi162F20B8"
+    },
+    "DeploymentId": {
+     "Ref": "myapiDeploymentB7EF8EB76dbd4bbbb18c5c458967fb55792b4830"
+    },
+    "StageName": "prod"
+   },
+   "DependsOn": [
+    "myapiAccountC3A4750C"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/DeploymentStage.prod/Resource"
+   }
+  },
+  "myapiproxyB6DF4575": {
+   "Type": "AWS::ApiGateway::Resource",
+   "Properties": {
+    "ParentId": {
+     "Fn::GetAtt": [
+      "myapi162F20B8",
+      "RootResourceId"
+     ]
+    },
+    "PathPart": "{proxy+}",
+    "RestApiId": {
+     "Ref": "myapi162F20B8"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Default/{proxy+}/Resource"
+   }
+  },
+  "myapiproxyANYApiPermissionCdkGeneralStackTestEuropemyapi65F2E57FANYproxyBDBDCB62": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandler2E4FBA4D",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:eu-west-1:",
+       {
+        "Ref": "AWS::AccountId"
+       },
+       ":",
+       {
+        "Ref": "myapi162F20B8"
+       },
+       "/",
+       {
+        "Ref": "myapiDeploymentStageprod329F21FF"
+       },
+       "/*/*"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Default/{proxy+}/ANY/ApiPermission.CdkGeneralStackTestEuropemyapi65F2E57F.ANY..{proxy+}"
+   }
+  },
+  "myapiproxyANYApiPermissionTestCdkGeneralStackTestEuropemyapi65F2E57FANYproxyF17A09F1": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandler2E4FBA4D",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:eu-west-1:",
+       {
+        "Ref": "AWS::AccountId"
+       },
+       ":",
+       {
+        "Ref": "myapi162F20B8"
+       },
+       "/test-invoke-stage/*/*"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Default/{proxy+}/ANY/ApiPermission.Test.CdkGeneralStackTestEuropemyapi65F2E57F.ANY..{proxy+}"
+   }
+  },
+  "myapiproxyANYDD7FCE64": {
+   "Type": "AWS::ApiGateway::Method",
+   "Properties": {
+    "HttpMethod": "ANY",
+    "ResourceId": {
+     "Ref": "myapiproxyB6DF4575"
+    },
+    "RestApiId": {
+     "Ref": "myapi162F20B8"
+    },
+    "AuthorizationType": "NONE",
+    "Integration": {
+     "IntegrationHttpMethod": "POST",
+     "Type": "AWS_PROXY",
+     "Uri": {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":apigateway:eu-west-1:lambda:path/2015-03-31/functions/",
+        {
+         "Fn::GetAtt": [
+          "HelloHandler2E4FBA4D",
+          "Arn"
+         ]
+        },
+        "/invocations"
+       ]
+      ]
+     }
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Default/{proxy+}/ANY/Resource"
+   }
+  },
+  "myapiANYApiPermissionCdkGeneralStackTestEuropemyapi65F2E57FANYEF4BF8F6": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandler2E4FBA4D",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:eu-west-1:",
+       {
+        "Ref": "AWS::AccountId"
+       },
+       ":",
+       {
+        "Ref": "myapi162F20B8"
+       },
+       "/",
+       {
+        "Ref": "myapiDeploymentStageprod329F21FF"
+       },
+       "/*/"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Default/ANY/ApiPermission.CdkGeneralStackTestEuropemyapi65F2E57F.ANY.."
+   }
+  },
+  "myapiANYApiPermissionTestCdkGeneralStackTestEuropemyapi65F2E57FANY3EBCCF8C": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandler2E4FBA4D",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:eu-west-1:",
+       {
+        "Ref": "AWS::AccountId"
+       },
+       ":",
+       {
+        "Ref": "myapi162F20B8"
+       },
+       "/test-invoke-stage/*/"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Default/ANY/ApiPermission.Test.CdkGeneralStackTestEuropemyapi65F2E57F.ANY.."
+   }
+  },
+  "myapiANY111D56B7": {
+   "Type": "AWS::ApiGateway::Method",
+   "Properties": {
+    "HttpMethod": "ANY",
+    "ResourceId": {
+     "Fn::GetAtt": [
+      "myapi162F20B8",
+      "RootResourceId"
+     ]
+    },
+    "RestApiId": {
+     "Ref": "myapi162F20B8"
+    },
+    "AuthorizationType": "NONE",
+    "Integration": {
+     "IntegrationHttpMethod": "POST",
+     "Type": "AWS_PROXY",
+     "Uri": {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":apigateway:eu-west-1:lambda:path/2015-03-31/functions/",
+        {
+         "Fn::GetAtt": [
+          "HelloHandler2E4FBA4D",
+          "Arn"
+         ]
+        },
+        "/invocations"
+       ]
+      ]
+     }
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Default/ANY/Resource"
+   }
+  },
+  "TableCD117FA1": {
+   "Type": "AWS::DynamoDB::Table",
+   "Properties": {
+    "KeySchema": [
+     {
+      "AttributeName": "id",
+      "KeyType": "HASH"
+     }
+    ],
+    "AttributeDefinitions": [
+     {
+      "AttributeName": "id",
+      "AttributeType": "S"
+     }
+    ],
+    "BillingMode": "PAY_PER_REQUEST"
+   },
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/Table/Resource"
+   }
+  },
+  "ruleF2C1DCDC": {
+   "Type": "AWS::Events::Rule",
+   "Properties": {
+    "EventPattern": {
+     "source": [
+      "aws.ec2"
+     ]
+    },
+    "State": "ENABLED",
+    "Targets": [
+     {
+      "Arn": {
+       "Fn::GetAtt": [
+        "HelloHandler2E4FBA4D",
+        "Arn"
+       ]
+      },
+      "DeadLetterConfig": {
+       "Arn": {
+        "Fn::GetAtt": [
+         "DeadLetterQueue9F481546",
+         "Arn"
+        ]
+       }
+      },
+      "Id": "Target0",
+      "RetryPolicy": {
+       "MaximumEventAgeInSeconds": 7200,
+       "MaximumRetryAttempts": 2
+      }
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/rule/Resource"
+   }
+  },
+  "ruleAllowEventRuleCdkGeneralStackTestEuropeHelloHandlerE25EBD9DD0F76E59": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandler2E4FBA4D",
+      "Arn"
+     ]
+    },
+    "Principal": "events.amazonaws.com",
+    "SourceArn": {
+     "Fn::GetAtt": [
+      "ruleF2C1DCDC",
+      "Arn"
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/rule/AllowEventRuleCdkGeneralStackTestEuropeHelloHandlerE25EBD9D"
+   }
+  },
+  "DeadLetterQueue9F481546": {
+   "Type": "AWS::SQS::Queue",
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete",
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/DeadLetterQueue/Resource"
+   }
+  },
+  "DeadLetterQueuePolicyB1FB890C": {
+   "Type": "AWS::SQS::QueuePolicy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sqs:SendMessage",
+       "Condition": {
+        "ArnEquals": {
+         "aws:SourceArn": {
+          "Fn::GetAtt": [
+           "ruleF2C1DCDC",
+           "Arn"
+          ]
+         }
+        }
+       },
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "events.amazonaws.com"
+       },
+       "Resource": {
+        "Fn::GetAtt": [
+         "DeadLetterQueue9F481546",
+         "Arn"
+        ]
+       },
+       "Sid": "AllowEventRuleCdkGeneralStackTestEuroperule6219EF60"
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "Queues": [
+     {
+      "Ref": "DeadLetterQueue9F481546"
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/DeadLetterQueue/Policy/Resource"
+   }
+  },
+  "CDKMetadata": {
+   "Type": "AWS::CDK::Metadata",
+   "Properties": {
+    "Analytics": "v2:deflate64:H4sIAAAAAAAA/02Q30/DIBDH/5a9M9SZmL12Gp801rr3hdKzshaoPdhsGv53D5izCeE+9z24Xxu+feC3K3HGtWy6da9qPn84ITtG0mFGg3ze20FJ9vhpEgTWC103gs/P3kinrImhJZcwaoVIXmBKaD5XtocYiDYwvD8IRHDIi2jI5zsvO3A7gcDEoFrh4CwmPr+kQhWgKwaVEvxjIaX1xrEnGHo7aSAkdeHRFG2qmoG+Wj9KSEXK0f5Mf8olceZXcF+2iVKmwJrJCG0b2ste1HmOBIHBierQfip/Gc+n8b5Jevfgk5Yh3aXtlZyuYnZDuHbG0jpit8q08dmbd4N3y/YCM7YBfsSb092W09msjqjUeqRNKA28yvYXs0P/r9UBAAA="
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-Europe/CDKMetadata/Default"
+   }
+  }
+ },
+ "Outputs": {
+  "myapiEndpoint8EB17201": {
+   "Value": {
+    "Fn::Join": [
+     "",
+     [
+      "https://",
+      {
+       "Ref": "myapi162F20B8"
+      },
+      ".execute-api.eu-west-1.",
+      {
+       "Ref": "AWS::URLSuffix"
+      },
+      "/",
+      {
+       "Ref": "myapiDeploymentStageprod329F21FF"
+      },
+      "/"
+     ]
+    ]
+   }
+  }
+ },
+ "Parameters": {
+  "BootstrapVersion": {
+   "Type": "AWS::SSM::Parameter::Value<String>",
+   "Default": "/cdk-bootstrap/hnb659fds/version",
+   "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]"
+  }
+ },
+ "Rules": {
+  "CheckBootstrapVersion": {
+   "Assertions": [
+    {
+     "Assert": {
+      "Fn::Not": [
+       {
+        "Fn::Contains": [
+         [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5"
+         ],
+         {
+          "Ref": "BootstrapVersion"
+         }
+        ]
+       }
+      ]
+     },
+     "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI."
+    }
+   ]
+  }
+ }
+}

--- a/cdk-test-project/tests/snapshot/fixtures/CdkGeneralStackTest-US.template.json
+++ b/cdk-test-project/tests/snapshot/fixtures/CdkGeneralStackTest-US.template.json
@@ -1,0 +1,971 @@
+{
+ "Transform": "SlicWatch-v3",
+ "Metadata": {
+  "slicWatch": {
+   "enabled": true,
+   "topicArn": "arn:aws:xxxxxx:mytopic",
+   "alarms": {
+    "Lambda": {
+     "Invocations": {
+      "enabled": true,
+      "Threshold": 10
+     }
+    },
+    "SQS": {
+     "AgeOfOldestMessage": {
+      "Statistic": "Maximum",
+      "enabled": true,
+      "Threshold": 60
+     },
+     "InFlightMessagesPc": {
+      "Statistic": "Maximum",
+      "Threshold": 1
+     }
+    }
+   },
+   "alarmActionsConfig": {
+    "alarmActions": [
+     {
+      "Ref": "MyTopic86869434"
+     }
+    ]
+   }
+  }
+ },
+ "Resources": {
+  "MyTopic86869434": {
+   "Type": "AWS::SNS::Topic",
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/MyTopic/Resource"
+   }
+  },
+  "HelloHandlerServiceRole11EF7C63": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/HelloHandler/ServiceRole/Resource"
+   }
+  },
+  "HelloHandler2E4FBA4D": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": {
+      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1"
+     },
+     "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "HelloHandlerServiceRole11EF7C63",
+      "Arn"
+     ]
+    },
+    "Handler": "hello.handler",
+    "Runtime": "nodejs18.x"
+   },
+   "DependsOn": [
+    "HelloHandlerServiceRole11EF7C63"
+   ],
+   "Metadata": {
+    "slicWatch": {
+     "alarms": {
+      "Lambda": {
+       "Invocations": {
+        "Threshold": 4
+       }
+      }
+     }
+    }
+   }
+  },
+  "PingHandlerServiceRole46086423": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/PingHandler/ServiceRole/Resource"
+   }
+  },
+  "PingHandler50068074": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": {
+      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1"
+     },
+     "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "PingHandlerServiceRole46086423",
+      "Arn"
+     ]
+    },
+    "Handler": "hello.handler",
+    "Runtime": "nodejs18.x"
+   },
+   "DependsOn": [
+    "PingHandlerServiceRole46086423"
+   ],
+   "Metadata": {
+    "slicWatch": {
+     "dashboard": {
+      "enabled": false
+     }
+    }
+   }
+  },
+  "ThrottlerHandlerServiceRoleA0481DAF": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/ThrottlerHandler/ServiceRole/Resource"
+   }
+  },
+  "ThrottlerHandler750A7C89": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": {
+      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1"
+     },
+     "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "ThrottlerHandlerServiceRoleA0481DAF",
+      "Arn"
+     ]
+    },
+    "Handler": "hello.handler",
+    "ReservedConcurrentExecutions": 0,
+    "Runtime": "nodejs18.x"
+   },
+   "DependsOn": [
+    "ThrottlerHandlerServiceRoleA0481DAF"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/ThrottlerHandler/Resource",
+    "aws:asset:path": "asset.03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640",
+    "aws:asset:is-bundled": false,
+    "aws:asset:property": "Code"
+   }
+  },
+  "DriveStreamHandlerServiceRoleD2BAFDD4": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/DriveStreamHandler/ServiceRole/Resource"
+   }
+  },
+  "DriveStreamHandler62F1767B": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": {
+      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1"
+     },
+     "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "DriveStreamHandlerServiceRoleD2BAFDD4",
+      "Arn"
+     ]
+    },
+    "Handler": "stream-test-handler.handleDrive",
+    "Runtime": "nodejs18.x"
+   },
+   "DependsOn": [
+    "DriveStreamHandlerServiceRoleD2BAFDD4"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/DriveStreamHandler/Resource",
+    "aws:asset:path": "asset.03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640",
+    "aws:asset:is-bundled": false,
+    "aws:asset:property": "Code"
+   }
+  },
+  "DriveQueueHandlerServiceRoleD796850A": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/DriveQueueHandler/ServiceRole/Resource"
+   }
+  },
+  "DriveQueueHandler9F657A00": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": {
+      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1"
+     },
+     "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "DriveQueueHandlerServiceRoleD796850A",
+      "Arn"
+     ]
+    },
+    "Handler": "hello.handler",
+    "Runtime": "nodejs18.x"
+   },
+   "DependsOn": [
+    "DriveQueueHandlerServiceRoleD796850A"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/DriveQueueHandler/Resource",
+    "aws:asset:path": "asset.03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640",
+    "aws:asset:is-bundled": false,
+    "aws:asset:property": "Code"
+   }
+  },
+  "DriveTableHandlerServiceRoleDDA3FBE1": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/DriveTableHandler/ServiceRole/Resource"
+   }
+  },
+  "DriveTableHandler119966B0": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": {
+      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-us-east-1"
+     },
+     "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "DriveTableHandlerServiceRoleDDA3FBE1",
+      "Arn"
+     ]
+    },
+    "Handler": "hello.handler",
+    "Runtime": "nodejs18.x"
+   },
+   "DependsOn": [
+    "DriveTableHandlerServiceRoleDDA3FBE1"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/DriveTableHandler/Resource",
+    "aws:asset:path": "asset.03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640",
+    "aws:asset:is-bundled": false,
+    "aws:asset:property": "Code"
+   }
+  },
+  "myapi162F20B8": {
+   "Type": "AWS::ApiGateway::RestApi",
+   "Properties": {
+    "Name": "myapi"
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Resource"
+   }
+  },
+  "myapiCloudWatchRoleEB425128": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "apigateway.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+       ]
+      ]
+     }
+    ]
+   },
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/myapi/CloudWatchRole/Resource"
+   }
+  },
+  "myapiAccountC3A4750C": {
+   "Type": "AWS::ApiGateway::Account",
+   "Properties": {
+    "CloudWatchRoleArn": {
+     "Fn::GetAtt": [
+      "myapiCloudWatchRoleEB425128",
+      "Arn"
+     ]
+    }
+   },
+   "DependsOn": [
+    "myapi162F20B8"
+   ],
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Account"
+   }
+  },
+  "myapiDeploymentB7EF8EB7fea2aa51ab5416f81a0b318c3a85d817": {
+   "Type": "AWS::ApiGateway::Deployment",
+   "Properties": {
+    "RestApiId": {
+     "Ref": "myapi162F20B8"
+    },
+    "Description": "Automatically created by the RestApi construct"
+   },
+   "DependsOn": [
+    "myapiproxyANYDD7FCE64",
+    "myapiproxyB6DF4575",
+    "myapiANY111D56B7"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Deployment/Resource"
+   }
+  },
+  "myapiDeploymentStageprod329F21FF": {
+   "Type": "AWS::ApiGateway::Stage",
+   "Properties": {
+    "RestApiId": {
+     "Ref": "myapi162F20B8"
+    },
+    "DeploymentId": {
+     "Ref": "myapiDeploymentB7EF8EB7fea2aa51ab5416f81a0b318c3a85d817"
+    },
+    "StageName": "prod"
+   },
+   "DependsOn": [
+    "myapiAccountC3A4750C"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/myapi/DeploymentStage.prod/Resource"
+   }
+  },
+  "myapiproxyB6DF4575": {
+   "Type": "AWS::ApiGateway::Resource",
+   "Properties": {
+    "ParentId": {
+     "Fn::GetAtt": [
+      "myapi162F20B8",
+      "RootResourceId"
+     ]
+    },
+    "PathPart": "{proxy+}",
+    "RestApiId": {
+     "Ref": "myapi162F20B8"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Default/{proxy+}/Resource"
+   }
+  },
+  "myapiproxyANYApiPermissionCdkGeneralStackTestUSmyapi9E6CC024ANYproxy61FC0812": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandler2E4FBA4D",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:us-east-1:",
+       {
+        "Ref": "AWS::AccountId"
+       },
+       ":",
+       {
+        "Ref": "myapi162F20B8"
+       },
+       "/",
+       {
+        "Ref": "myapiDeploymentStageprod329F21FF"
+       },
+       "/*/*"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Default/{proxy+}/ANY/ApiPermission.CdkGeneralStackTestUSmyapi9E6CC024.ANY..{proxy+}"
+   }
+  },
+  "myapiproxyANYApiPermissionTestCdkGeneralStackTestUSmyapi9E6CC024ANYproxy352B4E19": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandler2E4FBA4D",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:us-east-1:",
+       {
+        "Ref": "AWS::AccountId"
+       },
+       ":",
+       {
+        "Ref": "myapi162F20B8"
+       },
+       "/test-invoke-stage/*/*"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Default/{proxy+}/ANY/ApiPermission.Test.CdkGeneralStackTestUSmyapi9E6CC024.ANY..{proxy+}"
+   }
+  },
+  "myapiproxyANYDD7FCE64": {
+   "Type": "AWS::ApiGateway::Method",
+   "Properties": {
+    "HttpMethod": "ANY",
+    "ResourceId": {
+     "Ref": "myapiproxyB6DF4575"
+    },
+    "RestApiId": {
+     "Ref": "myapi162F20B8"
+    },
+    "AuthorizationType": "NONE",
+    "Integration": {
+     "IntegrationHttpMethod": "POST",
+     "Type": "AWS_PROXY",
+     "Uri": {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":apigateway:us-east-1:lambda:path/2015-03-31/functions/",
+        {
+         "Fn::GetAtt": [
+          "HelloHandler2E4FBA4D",
+          "Arn"
+         ]
+        },
+        "/invocations"
+       ]
+      ]
+     }
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Default/{proxy+}/ANY/Resource"
+   }
+  },
+  "myapiANYApiPermissionCdkGeneralStackTestUSmyapi9E6CC024ANY52E5EFEE": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandler2E4FBA4D",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:us-east-1:",
+       {
+        "Ref": "AWS::AccountId"
+       },
+       ":",
+       {
+        "Ref": "myapi162F20B8"
+       },
+       "/",
+       {
+        "Ref": "myapiDeploymentStageprod329F21FF"
+       },
+       "/*/"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Default/ANY/ApiPermission.CdkGeneralStackTestUSmyapi9E6CC024.ANY.."
+   }
+  },
+  "myapiANYApiPermissionTestCdkGeneralStackTestUSmyapi9E6CC024ANY1136CBF8": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandler2E4FBA4D",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:us-east-1:",
+       {
+        "Ref": "AWS::AccountId"
+       },
+       ":",
+       {
+        "Ref": "myapi162F20B8"
+       },
+       "/test-invoke-stage/*/"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Default/ANY/ApiPermission.Test.CdkGeneralStackTestUSmyapi9E6CC024.ANY.."
+   }
+  },
+  "myapiANY111D56B7": {
+   "Type": "AWS::ApiGateway::Method",
+   "Properties": {
+    "HttpMethod": "ANY",
+    "ResourceId": {
+     "Fn::GetAtt": [
+      "myapi162F20B8",
+      "RootResourceId"
+     ]
+    },
+    "RestApiId": {
+     "Ref": "myapi162F20B8"
+    },
+    "AuthorizationType": "NONE",
+    "Integration": {
+     "IntegrationHttpMethod": "POST",
+     "Type": "AWS_PROXY",
+     "Uri": {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":apigateway:us-east-1:lambda:path/2015-03-31/functions/",
+        {
+         "Fn::GetAtt": [
+          "HelloHandler2E4FBA4D",
+          "Arn"
+         ]
+        },
+        "/invocations"
+       ]
+      ]
+     }
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Default/ANY/Resource"
+   }
+  },
+  "TableCD117FA1": {
+   "Type": "AWS::DynamoDB::Table",
+   "Properties": {
+    "KeySchema": [
+     {
+      "AttributeName": "id",
+      "KeyType": "HASH"
+     }
+    ],
+    "AttributeDefinitions": [
+     {
+      "AttributeName": "id",
+      "AttributeType": "S"
+     }
+    ],
+    "BillingMode": "PAY_PER_REQUEST"
+   },
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/Table/Resource"
+   }
+  },
+  "ruleF2C1DCDC": {
+   "Type": "AWS::Events::Rule",
+   "Properties": {
+    "EventPattern": {
+     "source": [
+      "aws.ec2"
+     ]
+    },
+    "State": "ENABLED",
+    "Targets": [
+     {
+      "Arn": {
+       "Fn::GetAtt": [
+        "HelloHandler2E4FBA4D",
+        "Arn"
+       ]
+      },
+      "DeadLetterConfig": {
+       "Arn": {
+        "Fn::GetAtt": [
+         "DeadLetterQueue9F481546",
+         "Arn"
+        ]
+       }
+      },
+      "Id": "Target0",
+      "RetryPolicy": {
+       "MaximumEventAgeInSeconds": 7200,
+       "MaximumRetryAttempts": 2
+      }
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/rule/Resource"
+   }
+  },
+  "ruleAllowEventRuleCdkGeneralStackTestUSHelloHandlerC75B8B54C6DD839C": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandler2E4FBA4D",
+      "Arn"
+     ]
+    },
+    "Principal": "events.amazonaws.com",
+    "SourceArn": {
+     "Fn::GetAtt": [
+      "ruleF2C1DCDC",
+      "Arn"
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/rule/AllowEventRuleCdkGeneralStackTestUSHelloHandlerC75B8B54"
+   }
+  },
+  "DeadLetterQueue9F481546": {
+   "Type": "AWS::SQS::Queue",
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete",
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/DeadLetterQueue/Resource"
+   }
+  },
+  "DeadLetterQueuePolicyB1FB890C": {
+   "Type": "AWS::SQS::QueuePolicy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sqs:SendMessage",
+       "Condition": {
+        "ArnEquals": {
+         "aws:SourceArn": {
+          "Fn::GetAtt": [
+           "ruleF2C1DCDC",
+           "Arn"
+          ]
+         }
+        }
+       },
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "events.amazonaws.com"
+       },
+       "Resource": {
+        "Fn::GetAtt": [
+         "DeadLetterQueue9F481546",
+         "Arn"
+        ]
+       },
+       "Sid": "AllowEventRuleCdkGeneralStackTestUSruleB0D09E87"
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "Queues": [
+     {
+      "Ref": "DeadLetterQueue9F481546"
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/DeadLetterQueue/Policy/Resource"
+   }
+  },
+  "CDKMetadata": {
+   "Type": "AWS::CDK::Metadata",
+   "Properties": {
+    "Analytics": "v2:deflate64:H4sIAAAAAAAA/02Q30/DIBDH/5a9M9SZmL12Gp801rr3hdKzshaoPdhsGv53D5izCeE+9z24Xxu+feC3K3HGtWy6da9qPn84ITtG0mFGg3ze20FJ9vhpEgTWC103gs/P3kinrImhJZcwaoVIXmBKaD5XtocYiDYwvD8IRHDIi2jI5zsvO3A7gcDEoFrh4CwmPr+kQhWgKwaVEvxjIaX1xrEnGHo7aSAkdeHRFG2qmoG+Wj9KSEXK0f5Mf8olceZXcF+2iVKmwJrJCG0b2ste1HmOBIHBierQfip/Gc+n8b5Jevfgk5Yh3aXtlZyuYnZDuHbG0jpit8q08dmbd4N3y/YCM7YBfsSb092W09msjqjUeqRNKA28yvYXs0P/r9UBAAA="
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkGeneralStackTest-US/CDKMetadata/Default"
+   }
+  }
+ },
+ "Outputs": {
+  "myapiEndpoint8EB17201": {
+   "Value": {
+    "Fn::Join": [
+     "",
+     [
+      "https://",
+      {
+       "Ref": "myapi162F20B8"
+      },
+      ".execute-api.us-east-1.",
+      {
+       "Ref": "AWS::URLSuffix"
+      },
+      "/",
+      {
+       "Ref": "myapiDeploymentStageprod329F21FF"
+      },
+      "/"
+     ]
+    ]
+   }
+  }
+ },
+ "Parameters": {
+  "BootstrapVersion": {
+   "Type": "AWS::SSM::Parameter::Value<String>",
+   "Default": "/cdk-bootstrap/hnb659fds/version",
+   "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]"
+  }
+ },
+ "Rules": {
+  "CheckBootstrapVersion": {
+   "Assertions": [
+    {
+     "Assert": {
+      "Fn::Not": [
+       {
+        "Fn::Contains": [
+         [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5"
+         ],
+         {
+          "Ref": "BootstrapVersion"
+         }
+        ]
+       }
+      ]
+     },
+     "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI."
+    }
+   ]
+  }
+ }
+}

--- a/cdk-test-project/tests/snapshot/fixtures/CdkSFNStackTest-Europe.template.json
+++ b/cdk-test-project/tests/snapshot/fixtures/CdkSFNStackTest-Europe.template.json
@@ -1,0 +1,274 @@
+{
+ "Transform": "SlicWatch-v3",
+ "Metadata": {
+  "slicWatch": {
+   "enabled": true,
+   "alarms": {
+    "Lambda": {
+     "Invocations": {
+      "enabled": true,
+      "Threshold": 10
+     }
+    },
+    "SQS": {
+     "AgeOfOldestMessage": {
+      "Statistic": "Maximum",
+      "enabled": true,
+      "Threshold": 60
+     },
+     "InFlightMessagesPc": {
+      "Statistic": "Maximum",
+      "Threshold": 1
+     }
+    }
+   },
+   "topicArn": {
+    "Ref": "MyTopic86869434"
+   }
+  }
+ },
+ "Resources": {
+  "MyTopic86869434": {
+   "Type": "AWS::SNS::Topic",
+   "Metadata": {
+    "aws:cdk:path": "CdkSFNStackTest-Europe/MyTopic/Resource"
+   }
+  },
+  "HelloHandlerServiceRole11EF7C63": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkSFNStackTest-Europe/HelloHandler/ServiceRole/Resource"
+   }
+  },
+  "HelloHandler2E4FBA4D": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": {
+      "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-1"
+     },
+     "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "HelloHandlerServiceRole11EF7C63",
+      "Arn"
+     ]
+    },
+    "Handler": "hello.handler",
+    "Runtime": "nodejs18.x"
+   },
+   "DependsOn": [
+    "HelloHandlerServiceRole11EF7C63"
+   ],
+   "Metadata": {
+    "slicWatch": {
+     "alarms": {
+      "Lambda": {
+       "Invocations": {
+        "Threshold": 4
+       }
+      }
+     }
+    }
+   }
+  },
+  "StateMachineRoleB840431D": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "states.eu-west-1.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkSFNStackTest-Europe/StateMachine/Role/Resource"
+   }
+  },
+  "StateMachineRoleDefaultPolicyDF1E6607": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": "lambda:InvokeFunction",
+       "Effect": "Allow",
+       "Resource": [
+        {
+         "Fn::GetAtt": [
+          "HelloHandler2E4FBA4D",
+          "Arn"
+         ]
+        },
+        {
+         "Fn::Join": [
+          "",
+          [
+           {
+            "Fn::GetAtt": [
+             "HelloHandler2E4FBA4D",
+             "Arn"
+            ]
+           },
+           ":*"
+          ]
+         ]
+        }
+       ]
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "StateMachineRoleDefaultPolicyDF1E6607",
+    "Roles": [
+     {
+      "Ref": "StateMachineRoleB840431D"
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkSFNStackTest-Europe/StateMachine/Role/DefaultPolicy/Resource"
+   }
+  },
+  "StateMachine2E01A3A5": {
+   "Type": "AWS::StepFunctions::StateMachine",
+   "Properties": {
+    "RoleArn": {
+     "Fn::GetAtt": [
+      "StateMachineRoleB840431D",
+      "Arn"
+     ]
+    },
+    "DefinitionString": {
+     "Fn::Join": [
+      "",
+      [
+       "{\"StartAt\":\"Submit Job\",\"States\":{\"Submit Job\":{\"Next\":\"Wait X Seconds\",\"Retry\":[{\"ErrorEquals\":[\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2}],\"Type\":\"Task\",\"OutputPath\":\"$.Payload\",\"Resource\":\"arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":states:::lambda:invoke\",\"Parameters\":{\"FunctionName\":\"",
+       {
+        "Fn::GetAtt": [
+         "HelloHandler2E4FBA4D",
+         "Arn"
+        ]
+       },
+       "\",\"Payload.$\":\"$\"}},\"Wait X Seconds\":{\"Type\":\"Wait\",\"SecondsPath\":\"$.waitSeconds\",\"Next\":\"Get Job Status\"},\"Get Job Status\":{\"Next\":\"Job Complete?\",\"Retry\":[{\"ErrorEquals\":[\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2}],\"Type\":\"Task\",\"InputPath\":\"$.guid\",\"OutputPath\":\"$.Payload\",\"Resource\":\"arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":states:::lambda:invoke\",\"Parameters\":{\"FunctionName\":\"",
+       {
+        "Fn::GetAtt": [
+         "HelloHandler2E4FBA4D",
+         "Arn"
+        ]
+       },
+       "\",\"Payload.$\":\"$\"}},\"Job Complete?\":{\"Type\":\"Choice\",\"Choices\":[{\"Variable\":\"$.status\",\"StringEquals\":\"FAILED\",\"Next\":\"Job Failed\"},{\"Variable\":\"$.status\",\"StringEquals\":\"SUCCEEDED\",\"Next\":\"Get Final Job Status\"}],\"Default\":\"Wait X Seconds\"},\"Job Failed\":{\"Type\":\"Fail\",\"Error\":\"DescribeJob returned FAILED\",\"Cause\":\"AWS Batch Job Failed\"},\"Get Final Job Status\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2}],\"Type\":\"Task\",\"InputPath\":\"$.guid\",\"OutputPath\":\"$.Payload\",\"Resource\":\"arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":states:::lambda:invoke\",\"Parameters\":{\"FunctionName\":\"",
+       {
+        "Fn::GetAtt": [
+         "HelloHandler2E4FBA4D",
+         "Arn"
+        ]
+       },
+       "\",\"Payload.$\":\"$\"}}},\"TimeoutSeconds\":300}"
+      ]
+     ]
+    }
+   },
+   "DependsOn": [
+    "StateMachineRoleDefaultPolicyDF1E6607",
+    "StateMachineRoleB840431D"
+   ],
+   "UpdateReplacePolicy": "Delete",
+   "DeletionPolicy": "Delete",
+   "Metadata": {
+    "aws:cdk:path": "CdkSFNStackTest-Europe/StateMachine/Resource"
+   }
+  },
+  "CDKMetadata": {
+   "Type": "AWS::CDK::Metadata",
+   "Properties": {
+    "Analytics": "v2:deflate64:H4sIAAAAAAAA/11P0UoDQQz8lr7nolaQvtpCoaAgp+Djke6lbbp7u6XZq8iy/+7etoIIgZnJhEwyx8UT3s/oSxvT28bJFtN7JGOhtLqkXjF9hJMYWO18JRkcDdueMK1Hb6IEP1m/PIPQgKkNjqd2xbfgxHxP8soy6GNHqhwVnycoGpejsRyXpAwa+bS77dMuklrFl5q58Zdg/w1g+iSJsCZxsDoEMQzlgcivZA7i6xV/dc7QsobxXOZqeDH34vf12puRwYee8ah3l4cFlprPjirSnEcfZWBsr/gDsE52pTwBAAA="
+   },
+   "Metadata": {
+    "aws:cdk:path": "CdkSFNStackTest-Europe/CDKMetadata/Default"
+   }
+  }
+ },
+ "Parameters": {
+  "BootstrapVersion": {
+   "Type": "AWS::SSM::Parameter::Value<String>",
+   "Default": "/cdk-bootstrap/hnb659fds/version",
+   "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]"
+  }
+ },
+ "Rules": {
+  "CheckBootstrapVersion": {
+   "Assertions": [
+    {
+     "Assert": {
+      "Fn::Not": [
+       {
+        "Fn::Contains": [
+         [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5"
+         ],
+         {
+          "Ref": "BootstrapVersion"
+         }
+        ]
+       }
+      ]
+     },
+     "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI."
+    }
+   ]
+  }
+ }
+}

--- a/cdk-test-project/tsconfig.json
+++ b/cdk-test-project/tsconfig.json
@@ -5,7 +5,9 @@
     "lib": [
       "es2018"
     ],
+    "resolveJsonModule": true,
     "declaration": true,
+    "esModuleInterop": true,
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,

--- a/core/dashboards/tests/dashboard.test.ts
+++ b/core/dashboards/tests/dashboard.test.ts
@@ -1,4 +1,3 @@
-
 import _ from 'lodash'
 import { test } from 'tap'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "serverless-test-project",
         "serverless-test-project-alb",
         "serverless-test-project-appsync",
-        "sam-test-project"
+        "sam-test-project",
+        "test-utils"
       ],
       "dependencies": {
         "@types/lodash": "^4.14.191",
@@ -12794,6 +12795,10 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-utils": {
+      "resolved": "test-utils",
+      "link": true
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "dev": true,
@@ -13995,6 +14000,10 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
       "dev": true
+    },
+    "test-utils": {
+      "version": "3.1.0",
+      "license": "Apache"
     }
   },
   "dependencies": {
@@ -22733,6 +22742,9 @@
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
       }
+    },
+    "test-utils": {
+      "version": "file:test-utils"
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "serverless-test-project",
     "serverless-test-project-alb",
     "serverless-test-project-appsync",
-    "sam-test-project"
+    "sam-test-project",
+    "test-utils"
   ],
   "scripts": {
     "audit": "npm audit --omit dev fix && npm audit --workspaces --omit dev",
@@ -24,6 +25,7 @@
     "lint": "eslint .",
     "lintfix": "eslint --cache --fix .",
     "test:packages": "tap --include='**/tests/**/*.ts' --coverage-report=lcovonly --allow-incomplete-coverage",
+    "test:snapshots": "tap --include='**/tests/**/*snapshot.test.ts' --coverage-report=lcovonly --allow-incomplete-coverage",
     "test:report": "tap report html",
     "test": "npm run lint && npm run test:packages",
     "prepare": "test ! -d '.git' || is-ci || husky install",

--- a/sam-test-project/tests/snapshot/fixtures/sam-test-project-transformed-template.json
+++ b/sam-test-project/tests/snapshot/fixtures/sam-test-project-transformed-template.json
@@ -1,0 +1,1029 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "sam-test-project",
+  "Metadata": {
+    "slicWatch": {
+      "enabled": true,
+      "alarmActionsConfig": {
+        "alarmActions": [
+          {
+            "Ref": "MonitoringTopic"
+          }
+        ],
+        "okActions": [
+          {
+            "Ref": "MonitoringTopic"
+          }
+        ],
+        "actionsEnabled": true
+      },
+      "alarms": {
+        "Lambda": {
+          "Invocations": {
+            "enabled": true,
+            "Threshold": 10
+          }
+        },
+        "SQS": {
+          "AgeOfOldestMessage": {
+            "Statistic": "Maximum",
+            "enabled": true,
+            "Threshold": 60
+          },
+          "InFlightMessagesPc": {
+            "Statistic": "Maximum",
+            "Threshold": 1
+          }
+        }
+      }
+    }
+  },
+  "Resources": {
+    "MonitoringTopic": {
+      "Type": "AWS::SNS::Topic",
+      "Properties": {
+        "TopicName": "SS-Alarm-Topic3"
+      },
+      "Metadata": {
+        "SamResourceId": "MonitoringTopic"
+      }
+    },
+    "stream": {
+      "Type": "AWS::Kinesis::Stream",
+      "Properties": {
+        "ShardCount": 1
+      },
+      "Metadata": {
+        "SamResourceId": "stream"
+      }
+    },
+    "regularQueue": {
+      "Type": "AWS::SQS::Queue",
+      "Metadata": {
+        "SamResourceId": "regularQueue"
+      }
+    },
+    "fifoQueue": {
+      "Type": "AWS::SQS::Queue",
+      "Properties": {
+        "FifoQueue": true
+      },
+      "Metadata": {
+        "SamResourceId": "fifoQueue"
+      }
+    },
+    "vpc": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "CidrBlock": "10.0.0.0/16"
+      },
+      "Metadata": {
+        "SamResourceId": "vpc"
+      }
+    },
+    "subnet": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "AvailabilityZone": {
+          "Fn::Select": [
+            0,
+            {
+              "Fn::GetAZs": {
+                "Ref": "AWS::Region"
+              }
+            }
+          ]
+        },
+        "CidrBlock": "10.0.16.0/20",
+        "VpcId": {
+          "Ref": "vpc"
+        }
+      },
+      "Metadata": {
+        "SamResourceId": "subnet"
+      }
+    },
+    "ecsCluster": {
+      "Type": "AWS::ECS::Cluster",
+      "Metadata": {
+        "SamResourceId": "ecsCluster"
+      }
+    },
+    "ecsService": {
+      "Type": "AWS::ECS::Service",
+      "Properties": {
+        "Cluster": {
+          "Ref": "ecsCluster"
+        },
+        "DesiredCount": 0,
+        "LaunchType": "FARGATE",
+        "TaskDefinition": {
+          "Ref": "taskDef"
+        },
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "AssignPublicIp": "ENABLED",
+            "SecurityGroups": [],
+            "Subnets": [
+              {
+                "Ref": "subnet"
+              }
+            ]
+          }
+        }
+      },
+      "Metadata": {
+        "SamResourceId": "ecsService"
+      }
+    },
+    "taskDef": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "Cpu": 256,
+        "Memory": 512,
+        "ContainerDefinitions": [
+          {
+            "Name": "busybox",
+            "Image": "busybox",
+            "Cpu": 256,
+            "EntryPoint": [
+              "sh",
+              "-c"
+            ],
+            "Memory": 512,
+            "Command": [
+              "/bin/sh -c \"while true; do echo Hello; sleep 10; done\""
+            ],
+            "Essential": true
+          }
+        ],
+        "NetworkMode": "awsvpc"
+      },
+      "Metadata": {
+        "SamResourceId": "taskDef"
+      }
+    },
+    "dataTable": {
+      "Type": "AWS::DynamoDB::Table",
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "ProvisionedThroughput": {
+          "ReadCapacityUnits": 1,
+          "WriteCapacityUnits": 1
+        },
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "pk",
+            "AttributeType": "S"
+          },
+          {
+            "AttributeName": "sk",
+            "AttributeType": "S"
+          },
+          {
+            "AttributeName": "gsi1pk",
+            "AttributeType": "S"
+          },
+          {
+            "AttributeName": "gsi1sk",
+            "AttributeType": "S"
+          },
+          {
+            "AttributeName": "timestamp",
+            "AttributeType": "N"
+          }
+        ],
+        "KeySchema": [
+          {
+            "AttributeName": "pk",
+            "KeyType": "HASH"
+          },
+          {
+            "AttributeName": "sk",
+            "KeyType": "RANGE"
+          }
+        ],
+        "GlobalSecondaryIndexes": [
+          {
+            "IndexName": "GSI1",
+            "ProvisionedThroughput": {
+              "ReadCapacityUnits": 1,
+              "WriteCapacityUnits": 1
+            },
+            "KeySchema": [
+              {
+                "AttributeName": "gsi1pk",
+                "KeyType": "HASH"
+              },
+              {
+                "AttributeName": "gsi1sk",
+                "KeyType": "RANGE"
+              }
+            ],
+            "Projection": {
+              "NonKeyAttributes": [
+                "address"
+              ],
+              "ProjectionType": "INCLUDE"
+            }
+          }
+        ],
+        "LocalSecondaryIndexes": [
+          {
+            "IndexName": "LSI1",
+            "KeySchema": [
+              {
+                "AttributeName": "pk",
+                "KeyType": "HASH"
+              },
+              {
+                "AttributeName": "timestamp",
+                "KeyType": "RANGE"
+              }
+            ],
+            "Projection": {
+              "NonKeyAttributes": [
+                "name"
+              ],
+              "ProjectionType": "INCLUDE"
+            }
+          }
+        ]
+      },
+      "Metadata": {
+        "SamResourceId": "dataTable"
+      }
+    },
+    "hello": {
+      "Type": "AWS::Lambda::Function",
+      "Metadata": {
+        "SamResourceId": "hello",
+        "slicWatch": {
+          "alarms": {
+            "Lambda": {
+              "Invocations": {
+                "Threshold": 2
+              }
+            }
+          }
+        }
+      },
+      "Properties": {
+        "Code": {
+          "S3Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "S3Key": "sam-test-project/841a60f2d379216bd90fa34e033d0596"
+        },
+        "Handler": "basic-handler.hello",
+        "Role": {
+          "Fn::GetAtt": [
+            "helloRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "helloRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "ping": {
+      "Type": "AWS::Lambda::Function",
+      "Metadata": {
+        "SamResourceId": "ping",
+        "slicWatch": {
+          "dashboard": {
+            "enabled": false
+          }
+        }
+      },
+      "Properties": {
+        "Code": {
+          "S3Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "S3Key": "sam-test-project/841a60f2d379216bd90fa34e033d0596"
+        },
+        "Handler": "basic-handler.hello",
+        "Role": {
+          "Fn::GetAtt": [
+            "pingRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "pingRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "throttler": {
+      "Type": "AWS::Lambda::Function",
+      "Metadata": {
+        "SamResourceId": "throttler"
+      },
+      "Properties": {
+        "Code": {
+          "S3Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "S3Key": "sam-test-project/841a60f2d379216bd90fa34e033d0596"
+        },
+        "Handler": "basic-handler.hello",
+        "Role": {
+          "Fn::GetAtt": [
+            "throttlerRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "ReservedConcurrentExecutions": 0
+      }
+    },
+    "throttlerRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "driveStream": {
+      "Type": "AWS::Lambda::Function",
+      "Metadata": {
+        "SamResourceId": "driveStream"
+      },
+      "Properties": {
+        "Code": {
+          "S3Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "S3Key": "sam-test-project/841a60f2d379216bd90fa34e033d0596"
+        },
+        "Handler": "stream-test-handler.handleDrive",
+        "Role": {
+          "Fn::GetAtt": [
+            "driveStreamRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "driveStreamRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "driveQueue": {
+      "Type": "AWS::Lambda::Function",
+      "Metadata": {
+        "SamResourceId": "driveQueue"
+      },
+      "Properties": {
+        "Code": {
+          "S3Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "S3Key": "sam-test-project/841a60f2d379216bd90fa34e033d0596"
+        },
+        "Handler": "basic-handler.hello",
+        "Role": {
+          "Fn::GetAtt": [
+            "driveQueueRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "driveQueueRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "driveTable": {
+      "Type": "AWS::Lambda::Function",
+      "Metadata": {
+        "SamResourceId": "driveTable"
+      },
+      "Properties": {
+        "Code": {
+          "S3Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "S3Key": "sam-test-project/841a60f2d379216bd90fa34e033d0596"
+        },
+        "Handler": "basic-handler.hello",
+        "Role": {
+          "Fn::GetAtt": [
+            "driveTableRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "driveTableRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "streamProcessor": {
+      "Type": "AWS::Lambda::Function",
+      "Metadata": {
+        "SamResourceId": "streamProcessor"
+      },
+      "Properties": {
+        "Code": {
+          "S3Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "S3Key": "sam-test-project/841a60f2d379216bd90fa34e033d0596"
+        },
+        "Handler": "basic-handler.hello",
+        "Role": {
+          "Fn::GetAtt": [
+            "streamProcessorRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "streamProcessorRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "streamProcessorStream": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "stream",
+            "Arn"
+          ]
+        },
+        "FunctionName": {
+          "Ref": "streamProcessor"
+        },
+        "MaximumRetryAttempts": 0,
+        "StartingPosition": "LATEST"
+      }
+    },
+    "httpGetter": {
+      "Type": "AWS::Lambda::Function",
+      "Metadata": {
+        "SamResourceId": "httpGetter"
+      },
+      "Properties": {
+        "Code": {
+          "S3Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "S3Key": "sam-test-project/841a60f2d379216bd90fa34e033d0596"
+        },
+        "Handler": "apigw-handler.handleGet",
+        "Role": {
+          "Fn::GetAtt": [
+            "httpGetterRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 30,
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "httpGetterRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "httpGetterHttpApiEventPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "httpGetter"
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GETitem",
+            {
+              "__ApiId__": {
+                "Ref": "ServerlessHttpApi"
+              },
+              "__Stage__": "*"
+            }
+          ]
+        }
+      }
+    },
+    "eventsRule": {
+      "Type": "AWS::Lambda::Function",
+      "Metadata": {
+        "SamResourceId": "eventsRule",
+        "slicWatch": {
+          "alarms": {
+            "Lambda": {
+              "enabled": false
+            }
+          }
+        }
+      },
+      "Properties": {
+        "Code": {
+          "S3Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "S3Key": "sam-test-project/841a60f2d379216bd90fa34e033d0596"
+        },
+        "Handler": "rule-handler.handleRule",
+        "Role": {
+          "Fn::GetAtt": [
+            "eventsRuleRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "eventsRuleRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "eventsRuleTrigger": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "EventPattern": {
+          "detail-type": [
+            "Invoke Lambda Function"
+          ]
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "eventsRule",
+                "Arn"
+              ]
+            },
+            "Id": "eventsRuleTriggerLambdaTarget",
+            "RetryPolicy": {
+              "MaximumRetryAttempts": 0,
+              "MaximumEventAgeInSeconds": 60
+            }
+          }
+        ]
+      }
+    },
+    "eventsRuleTriggerPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "eventsRule"
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "eventsRuleTrigger",
+            "Arn"
+          ]
+        }
+      }
+    },
+    "TestStateMachine": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Metadata": {
+        "SamResourceId": "TestStateMachine"
+      },
+      "Properties": {
+        "DefinitionS3Location": {
+          "Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "Key": "sam-test-project/754f906d12f592f99c5651c04a6a0a51"
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "TestStateMachineRole",
+            "Arn"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "DefinitionSubstitutions": {
+          "HelloArn": {
+            "Fn::GetAtt": [
+              "hello",
+              "Arn"
+            ]
+          },
+          "AnotherHelloArn": {
+            "Fn::GetAtt": [
+              "hello",
+              "Arn"
+            ]
+          }
+        }
+      }
+    },
+    "TestStateMachineRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "states.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        },
+        "ManagedPolicyArns": [],
+        "Policies": [
+          {
+            "PolicyName": "TestStateMachineRolePolicy0",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "lambda:InvokeFunction"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*",
+                      {
+                        "functionName": {
+                          "Ref": "hello"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "PolicyName": "TestStateMachineRolePolicy1",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "lambda:InvokeFunction"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*",
+                      {
+                        "functionName": {
+                          "Ref": "hello"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "ServerlessHttpApi": {
+      "Type": "AWS::ApiGatewayV2::Api",
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0",
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          },
+          "paths": {
+            "item": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
+                  "uri": {
+                    "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${httpGetter.Arn}/invocations"
+                  },
+                  "payloadFormatVersion": "2.0"
+                },
+                "responses": {}
+              }
+            }
+          },
+          "openapi": "3.0.1",
+          "tags": [
+            {
+              "name": "httpapi:createdBy",
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ]
+        }
+      }
+    },
+    "ServerlessHttpApiApiGatewayDefaultStage": {
+      "Type": "AWS::ApiGatewayV2::Stage",
+      "Properties": {
+        "ApiId": {
+          "Ref": "ServerlessHttpApi"
+        },
+        "StageName": "$default",
+        "Tags": {
+          "httpapi:createdBy": "SAM"
+        },
+        "AutoDeploy": true
+      }
+    }
+  }
+}

--- a/sam-test-project/tests/snapshot/sam-test-project-snapshot.test.ts
+++ b/sam-test-project/tests/snapshot/sam-test-project-snapshot.test.ts
@@ -1,0 +1,14 @@
+import { test } from 'tap'
+import type { Template } from 'cloudform'
+import { handler } from 'cf-macro-slic-watch/index'
+
+import inputTemplate from './fixtures/sam-test-project-transformed-template.json'
+
+test('sam-test-project snapshot', async (t) => {
+  const response = await handler({ fragment: inputTemplate as Template, requestId: 'snapshot-test' })
+  t.notOk(response.errorMessage)
+  t.equal(response.status, 'success')
+  t.equal(response.requestId, 'snapshot-test')
+  t.matchSnapshot(response.fragment, 'fragment')
+  t.end()
+})

--- a/serverless-test-project-alb/tests/snapshot/fixtures/cloudformation-template-update-stack.json
+++ b/serverless-test-project-alb/tests/snapshot/fixtures/cloudformation-template-update-stack.json
@@ -1,0 +1,561 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "The AWS CloudFormation template for this Serverless application",
+  "Resources": {
+    "ServerlessDeploymentBucket": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ServerlessDeploymentBucketPolicy": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "ServerlessDeploymentBucket"
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "ServerlessDeploymentBucket"
+                      },
+                      "/*"
+                    ]
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "ServerlessDeploymentBucket"
+                      }
+                    ]
+                  ]
+                }
+              ],
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": false
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "AlbEventLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/serverless-test-project-alb-dev-albEvent"
+      }
+    },
+    "IamRoleLambdaExecution": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRole"
+              ]
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": {
+              "Fn::Join": [
+                "-",
+                [
+                  "serverless-test-project-alb",
+                  "dev",
+                  "lambda"
+                ]
+              ]
+            },
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "logs:CreateLogStream",
+                    "logs:CreateLogGroup",
+                    "logs:TagResource"
+                  ],
+                  "Resource": [
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/serverless-test-project-alb-dev*:*"
+                    }
+                  ]
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "logs:PutLogEvents"
+                  ],
+                  "Resource": [
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/serverless-test-project-alb-dev*:*:*"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "Path": "/",
+        "RoleName": {
+          "Fn::Join": [
+            "-",
+            [
+              "serverless-test-project-alb",
+              "dev",
+              {
+                "Ref": "AWS::Region"
+              },
+              "lambdaRole"
+            ]
+          ]
+        }
+      }
+    },
+    "AlbEventLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/serverless-test-project-alb/dev/1701242684385-2023-11-29T07:24:44.385Z/serverless-test-project-alb.zip"
+        },
+        "Handler": "alb-handler.handleALB",
+        "Runtime": "nodejs18.x",
+        "FunctionName": "serverless-test-project-alb-dev-albEvent",
+        "MemorySize": 1024,
+        "Timeout": 6,
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "AlbEventLogGroup"
+      ],
+      "Metadata": {
+        "slicWatch": {}
+      }
+    },
+    "AlbEventLambdaVersion0XznAenLykwY99KhRhuWhGA2GO8nTdlRqGtjPoaDgg": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "AlbEventLambdaFunction"
+        },
+        "CodeSha256": "iF0ZcJ5dWZd/RnBzvEqO7WAQlHbLsco8p4dUx4U7AL8="
+      }
+    },
+    "AlbEventAlbTargetGrouphttpListener": {
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "Properties": {
+        "TargetType": "lambda",
+        "Targets": [
+          {
+            "Id": {
+              "Fn::GetAtt": [
+                "AlbEventLambdaFunction",
+                "Arn"
+              ]
+            }
+          }
+        ],
+        "Name": "1d5fdfd5099ec257209ef7b7c5ee8cb4",
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "serverless-test-project-alb-albEvent-httpListener-dev"
+          }
+        ],
+        "TargetGroupAttributes": [
+          {
+            "Key": "lambda.multi_value_headers.enabled",
+            "Value": false
+          }
+        ],
+        "HealthCheckEnabled": true,
+        "HealthCheckPath": "/",
+        "HealthCheckIntervalSeconds": 35,
+        "HealthCheckTimeoutSeconds": 30,
+        "HealthyThresholdCount": 5,
+        "UnhealthyThresholdCount": 5,
+        "Matcher": {
+          "HttpCode": "200"
+        }
+      },
+      "DependsOn": [
+        "AlbEventLambdaPermissionRegisterTarget"
+      ]
+    },
+    "AlbEventAlbListenerRule1": {
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+      "Properties": {
+        "Actions": [
+          {
+            "Type": "forward",
+            "TargetGroupArn": {
+              "Ref": "AlbEventAlbTargetGrouphttpListener"
+            }
+          }
+        ],
+        "Conditions": [
+          {
+            "Field": "path-pattern",
+            "Values": [
+              "/handleALB"
+            ]
+          },
+          {
+            "Field": "http-request-method",
+            "HttpRequestMethodConfig": {
+              "Values": [
+                "POST"
+              ]
+            }
+          }
+        ],
+        "ListenerArn": {
+          "Ref": "httpListener"
+        },
+        "Priority": 1
+      }
+    },
+    "AlbEventLambdaPermissionAlb": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "AlbEventLambdaFunction",
+            "Arn"
+          ]
+        },
+        "Action": "lambda:InvokeFunction",
+        "Principal": "elasticloadbalancing.amazonaws.com",
+        "SourceArn": {
+          "Ref": "AlbEventAlbTargetGrouphttpListener"
+        }
+      }
+    },
+    "AlbEventLambdaPermissionRegisterTarget": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "AlbEventLambdaFunction",
+            "Arn"
+          ]
+        },
+        "Action": "lambda:InvokeFunction",
+        "Principal": "elasticloadbalancing.amazonaws.com"
+      }
+    },
+    "bucket": {
+      "Type": "AWS::S3::Bucket"
+    },
+    "vpcALB": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "CidrBlock": "10.0.0.0/20",
+        "EnableDnsSupport": true,
+        "EnableDnsHostnames": true,
+        "InstanceTenancy": "default",
+        "Tags": [
+          {
+            "Key": "ProjectName",
+            "Value": "serverless-test-project-alb"
+          },
+          {
+            "Key": "Stage",
+            "Value": "dev"
+          }
+        ]
+      }
+    },
+    "internetGateway": {
+      "Type": "AWS::EC2::InternetGateway",
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "ProjectName",
+            "Value": "serverless-test-project-alb"
+          },
+          {
+            "Key": "Stage",
+            "Value": "dev"
+          }
+        ]
+      }
+    },
+    "vpcGatewayAttachment": {
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Properties": {
+        "VpcId": {
+          "Ref": "vpcALB"
+        },
+        "InternetGatewayId": {
+          "Ref": "internetGateway"
+        }
+      }
+    },
+    "subnetA": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "AvailabilityZone": "eu-west-1a",
+        "CidrBlock": "10.0.5.0/24",
+        "VpcId": {
+          "Ref": "vpcALB"
+        },
+        "Tags": [
+          {
+            "Key": "ProjectName",
+            "Value": "serverless-test-project-alb"
+          },
+          {
+            "Key": "Stage",
+            "Value": "dev"
+          }
+        ]
+      }
+    },
+    "subnetB": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "AvailabilityZone": "eu-west-1b",
+        "CidrBlock": "10.0.6.0/24",
+        "VpcId": {
+          "Ref": "vpcALB"
+        },
+        "Tags": [
+          {
+            "Key": "ProjectName",
+            "Value": "serverless-test-project-alb"
+          },
+          {
+            "Key": "Stage",
+            "Value": "dev"
+          }
+        ]
+      }
+    },
+    "routeTableA": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "vpcALB"
+        },
+        "Tags": [
+          {
+            "Key": "ProjectName",
+            "Value": "serverless-test-project-alb"
+          },
+          {
+            "Key": "Stage",
+            "Value": "dev"
+          }
+        ]
+      }
+    },
+    "routeTableB": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "vpcALB"
+        },
+        "Tags": [
+          {
+            "Key": "ProjectName",
+            "Value": "serverless-test-project-alb"
+          },
+          {
+            "Key": "Stage",
+            "Value": "dev"
+          }
+        ]
+      }
+    },
+    "routeTableAssociationSubnetA": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "subnetA"
+        },
+        "RouteTableId": {
+          "Ref": "routeTableA"
+        }
+      }
+    },
+    "routeTableAssociationSubnetB": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "subnetB"
+        },
+        "RouteTableId": {
+          "Ref": "routeTableB"
+        }
+      }
+    },
+    "routeTableAInternetRoute": {
+      "Type": "AWS::EC2::Route",
+      "DependsOn": [
+        "vpcGatewayAttachment"
+      ],
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "routeTableA"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "internetGateway"
+        }
+      }
+    },
+    "routeTableBInternetRoute": {
+      "Type": "AWS::EC2::Route",
+      "DependsOn": [
+        "vpcGatewayAttachment"
+      ],
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "routeTableB"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "internetGateway"
+        }
+      }
+    },
+    "alb": {
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Properties": {
+        "Name": "awesome-loadBalancer",
+        "Type": "application",
+        "Subnets": [
+          {
+            "Ref": "subnetA"
+          },
+          {
+            "Ref": "subnetB"
+          }
+        ],
+        "SecurityGroups": [
+          {
+            "Ref": "albSecurityGroup"
+          }
+        ]
+      }
+    },
+    "httpListener": {
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+      "Properties": {
+        "LoadBalancerArn": {
+          "Ref": "alb"
+        },
+        "Port": 80,
+        "Protocol": "HTTP",
+        "DefaultActions": [
+          {
+            "Type": "redirect",
+            "RedirectConfig": {
+              "Protocol": "HTTP",
+              "Port": 400,
+              "Host": "#{host}",
+              "Path": "/#{path}",
+              "Query": "#{query}",
+              "StatusCode": "HTTP_301"
+            }
+          }
+        ]
+      }
+    },
+    "albSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Allow http to client host",
+        "VpcId": {
+          "Ref": "vpcALB"
+        },
+        "SecurityGroupIngress": [
+          {
+            "IpProtocol": "tcp",
+            "FromPort": 80,
+            "ToPort": 80,
+            "CidrIp": "0.0.0.0/0"
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": 443,
+            "ToPort": 443,
+            "CidrIp": "0.0.0.0/0"
+          }
+        ]
+      }
+    }
+  },
+  "Outputs": {
+    "ServerlessDeploymentBucketName": {
+      "Value": {
+        "Ref": "ServerlessDeploymentBucket"
+      },
+      "Export": {
+        "Name": "sls-serverless-test-project-alb-dev-ServerlessDeploymentBucketName"
+      }
+    },
+    "AlbEventLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "AlbEventLambdaVersion0XznAenLykwY99KhRhuWhGA2GO8nTdlRqGtjPoaDgg"
+      },
+      "Export": {
+        "Name": "sls-serverless-test-project-alb-dev-AlbEventLambdaFunctionQualifiedArn"
+      }
+    }
+  }
+}

--- a/serverless-test-project-alb/tests/snapshot/serverless-test-project-alb-snapshot.test.ts
+++ b/serverless-test-project-alb/tests/snapshot/serverless-test-project-alb-snapshot.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'tap'
+import ServerlessPlugin from 'serverless-slic-watch-plugin/serverless-plugin'
+
+import inputTemplate from './fixtures/cloudformation-template-update-stack.json'
+import { createMockServerless } from 'test-utils/sls-test-utils'
+import type { ResourceType } from 'slic-watch-core'
+
+const logger = {}
+
+const pluginUtils = { log: logger }
+
+test('serverless-test-project-alb snapshot', (t) => {
+  const mockServerless = createMockServerless(inputTemplate.Resources as ResourceType)
+  const plugin = new ServerlessPlugin(mockServerless, null, pluginUtils)
+  plugin.createSlicWatchResources()
+  const generatedTemplate = mockServerless.service.provider.compiledCloudFormationTemplate
+  t.matchSnapshot(generatedTemplate, 'serverless-test-project-alb template')
+  t.end()
+})

--- a/serverless-test-project-appsync/tests/snapshot/fixtures/cloudformation-template-update-stack.json
+++ b/serverless-test-project-appsync/tests/snapshot/fixtures/cloudformation-template-update-stack.json
@@ -1,0 +1,516 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "The AWS CloudFormation template for this Serverless application",
+  "Resources": {
+    "ServerlessDeploymentBucket": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ServerlessDeploymentBucketPolicy": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "ServerlessDeploymentBucket"
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "ServerlessDeploymentBucket"
+                      },
+                      "/*"
+                    ]
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "ServerlessDeploymentBucket"
+                      }
+                    ]
+                  ]
+                }
+              ],
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": false
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "bucket": {
+      "Type": "AWS::S3::Bucket"
+    },
+    "BooksTable": {
+      "Type": "AWS::DynamoDB::Table",
+      "Properties": {
+        "BillingMode": "PAY_PER_REQUEST",
+        "KeySchema": [
+          {
+            "AttributeName": "bookId",
+            "KeyType": "HASH"
+          }
+        ],
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "bookId",
+            "AttributeType": "S"
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "books-table"
+          }
+        ]
+      }
+    },
+    "CognitoUserPool": {
+      "Type": "AWS::Cognito::UserPool",
+      "Properties": {
+        "AutoVerifiedAttributes": [
+          "email"
+        ],
+        "Policies": {
+          "PasswordPolicy": {
+            "MinimumLength": 8,
+            "RequireLowercase": false,
+            "RequireNumbers": false,
+            "RequireUppercase": false,
+            "RequireSymbols": false
+          }
+        },
+        "UsernameAttributes": [
+          "email"
+        ],
+        "Schema": [
+          {
+            "AttributeDataType": "String",
+            "Name": "name",
+            "Required": false,
+            "Mutable": true
+          }
+        ],
+        "UserPoolName": "BookStoreUserPool"
+      }
+    },
+    "CognitoUserPoolClient": {
+      "Type": "AWS::Cognito::UserPoolClient",
+      "Properties": {
+        "UserPoolId": {
+          "Ref": "CognitoUserPool"
+        },
+        "ClientName": "web",
+        "ExplicitAuthFlows": [
+          "ALLOW_USER_SRP_AUTH",
+          "ALLOW_USER_PASSWORD_AUTH",
+          "ALLOW_REFRESH_TOKEN_AUTH"
+        ],
+        "PreventUserExistenceErrors": "ENABLED"
+      }
+    },
+    "CognitoAdminGroup": {
+      "Type": "AWS::Cognito::UserPoolGroup",
+      "Properties": {
+        "UserPoolId": {
+          "Ref": "CognitoUserPool"
+        },
+        "GroupName": "Admin",
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "CognitoAdminIAMrole",
+            "Arn"
+          ]
+        },
+        "Description": "Admin users belong to this group"
+      }
+    },
+    "CognitoAdminIAMrole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "cognito-identity.amazonaws.com"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ]
+            }
+          ]
+        },
+        "Description": "This is the IAM role that admin group users name",
+        "Policies": [
+          {
+            "PolicyName": "bookstore-admin-group-policy",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "dynamodb:*"
+                  ],
+                  "Resource": [
+                    {
+                      "Fn::GetAtt": [
+                        "BooksTable",
+                        "Arn"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "RoleName": "bookstore-admin-role"
+      }
+    },
+    "CognitoCustomerGroup": {
+      "Type": "AWS::Cognito::UserPoolGroup",
+      "Properties": {
+        "UserPoolId": {
+          "Ref": "CognitoUserPool"
+        },
+        "GroupName": "Customer",
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "CognitoUserIAMrole",
+            "Arn"
+          ]
+        },
+        "Description": "Customer belongs to this group"
+      }
+    },
+    "CognitoUserIAMrole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": [
+                  "cognito-identity.amazonaws.com"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ]
+            }
+          ]
+        },
+        "Description": "This is the IAM role that admin group users name",
+        "Policies": [
+          {
+            "PolicyName": "book-store-customer-group-policy",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "dynamodb:GetItem",
+                    "dynamodb:Query",
+                    "dynamodb:BatchGetItem"
+                  ],
+                  "Resource": [
+                    {
+                      "Fn::GetAtt": [
+                        "BooksTable",
+                        "Arn"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "RoleName": "bookstore-customer-role"
+      }
+    },
+    "AwesomeappsyncGraphQlApi": {
+      "Type": "AWS::AppSync::GraphQLApi",
+      "Properties": {
+        "Name": "awesome-appsync",
+        "AuthenticationType": "AMAZON_COGNITO_USER_POOLS",
+        "AdditionalAuthenticationProviders": [],
+        "UserPoolConfig": {
+          "AwsRegion": "eu-west-1",
+          "UserPoolId": {
+            "Ref": "CognitoUserPool"
+          },
+          "DefaultAction": "ALLOW"
+        },
+        "XrayEnabled": false
+      }
+    },
+    "AwesomeappsyncGraphQlSchema": {
+      "Type": "AWS::AppSync::GraphQLSchema",
+      "Properties": {
+        "Definition": "schema {\n  query: Query\n  mutation: Mutation\n  subscription: Subscription\n}\n\ntype Subscription {\n  onCreateBook: Book @aws_subscribe(mutations: [\"createBook\"])\n}\n\ntype Query {\n  getBookById(bookId: ID!): Book!\n}\n\ntype Book {\n  bookId: ID!\n  title: String!\n  description: String\n  imageUrl: AWSURL\n  author: String!\n  price: Float!\n  createdAt: AWSDateTime!\n  updatedAt: AWSDateTime!\n}\n\ntype Mutation {\n  createBook(newBook: BookInput): Book! @aws_auth(cognito_groups: [\"Admin\"])\n}\n\ninput BookInput {\n  title: String!\n  description: String\n  imageUrl: AWSURL\n  author: String!\n  price: Float!\n}",
+        "ApiId": {
+          "Fn::GetAtt": [
+            "AwesomeappsyncGraphQlApi",
+            "ApiId"
+          ]
+        }
+      }
+    },
+    "AwesomeappsyncGraphQlDsbooksTableRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "appsync.amazonaws.com"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRole"
+              ]
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": "GraphQlDsbooksTablePolicy",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Action": [
+                    "dynamodb:DeleteItem",
+                    "dynamodb:GetItem",
+                    "dynamodb:PutItem",
+                    "dynamodb:Query",
+                    "dynamodb:Scan",
+                    "dynamodb:UpdateItem",
+                    "dynamodb:BatchGetItem",
+                    "dynamodb:BatchWriteItem",
+                    "dynamodb:ConditionCheckItem"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Join": [
+                        ":",
+                        [
+                          "arn",
+                          "aws",
+                          "dynamodb",
+                          "eu-west-1",
+                          {
+                            "Ref": "AWS::AccountId"
+                          },
+                          {
+                            "Fn::Join": [
+                              "/",
+                              [
+                                "table",
+                                {
+                                  "Ref": "BooksTable"
+                                }
+                              ]
+                            ]
+                          }
+                        ]
+                      ]
+                    },
+                    {
+                      "Fn::Join": [
+                        "/",
+                        [
+                          {
+                            "Fn::Join": [
+                              ":",
+                              [
+                                "arn",
+                                "aws",
+                                "dynamodb",
+                                "eu-west-1",
+                                {
+                                  "Ref": "AWS::AccountId"
+                                },
+                                {
+                                  "Fn::Join": [
+                                    "/",
+                                    [
+                                      "table",
+                                      {
+                                        "Ref": "BooksTable"
+                                      }
+                                    ]
+                                  ]
+                                }
+                              ]
+                            ]
+                          },
+                          "*"
+                        ]
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "AwesomeappsyncGraphQlDsbooksTable": {
+      "Type": "AWS::AppSync::DataSource",
+      "Properties": {
+        "ApiId": {
+          "Fn::GetAtt": [
+            "AwesomeappsyncGraphQlApi",
+            "ApiId"
+          ]
+        },
+        "Name": "booksTable",
+        "Type": "AMAZON_DYNAMODB",
+        "ServiceRoleArn": {
+          "Fn::GetAtt": [
+            "AwesomeappsyncGraphQlDsbooksTableRole",
+            "Arn"
+          ]
+        },
+        "DynamoDBConfig": {
+          "AwsRegion": "eu-west-1",
+          "TableName": {
+            "Ref": "BooksTable"
+          },
+          "UseCallerCredentials": false,
+          "Versioned": false
+        }
+      }
+    },
+    "AwesomeappsyncGraphQlResolverQuerygetBookById": {
+      "Type": "AWS::AppSync::Resolver",
+      "DependsOn": "AwesomeappsyncGraphQlSchema",
+      "Properties": {
+        "ApiId": {
+          "Fn::GetAtt": [
+            "AwesomeappsyncGraphQlApi",
+            "ApiId"
+          ]
+        },
+        "TypeName": "Query",
+        "FieldName": "getBookById",
+        "RequestMappingTemplate": "#if ($context.info.selectionSetList.size() == 1 && $context.info.selectionSetList[0] == \"id\")\n  #set ($result = { \"id\": \"$context.source.otherUserId\" })\n\n  #return($result)\n#end\n\n{\n  \"version\" : \"2018-05-29\",\n  \"operation\" : \"GetItem\",\n  \"key\" : {\n    \"bookId\" : $util.dynamodb.toDynamoDBJson($context.arguments.bookId)\n  }\n}",
+        "ResponseMappingTemplate": "$util.toJson($context.result)",
+        "Kind": "UNIT",
+        "DataSourceName": {
+          "Fn::GetAtt": [
+            "AwesomeappsyncGraphQlDsbooksTable",
+            "Name"
+          ]
+        }
+      }
+    },
+    "AwesomeappsyncGraphQlResolverMutationcreateBook": {
+      "Type": "AWS::AppSync::Resolver",
+      "DependsOn": "AwesomeappsyncGraphQlSchema",
+      "Properties": {
+        "ApiId": {
+          "Fn::GetAtt": [
+            "AwesomeappsyncGraphQlApi",
+            "ApiId"
+          ]
+        },
+        "TypeName": "Mutation",
+        "FieldName": "createBook",
+        "RequestMappingTemplate": "{\n    \"version\" : \"2018-05-29\",\n    \"operation\" : \"PutItem\",\n    \"key\": {\n        \"bookId\" : $util.dynamodb.toDynamoDBJson($util.autoId())\n    },\n    \"attributeValues\" : {\n        \"title\" : $util.dynamodb.toDynamoDBJson($context.arguments.newBook.title),\n        \"description\" : $util.dynamodb.toDynamoDBJson($context.arguments.newBook.description),\n        \"imageUrl\" : $util.dynamodb.toDynamoDBJson($context.arguments.newBook.imageUrl),\n        \"author\" : $util.dynamodb.toDynamoDBJson($context.arguments.newBook.author),\n        \"price\" : $util.dynamodb.toDynamoDBJson($context.arguments.newBook.price),\n        \"createdAt\": $util.dynamodb.toDynamoDBJson($util.time.nowISO8601()),\n        \"updatedAt\": $util.dynamodb.toDynamoDBJson($util.time.nowISO8601())\n    }\n}",
+        "ResponseMappingTemplate": "$util.toJson($context.result)",
+        "Kind": "UNIT",
+        "DataSourceName": {
+          "Fn::GetAtt": [
+            "AwesomeappsyncGraphQlDsbooksTable",
+            "Name"
+          ]
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "ServerlessDeploymentBucketName": {
+      "Value": {
+        "Ref": "ServerlessDeploymentBucket"
+      },
+      "Export": {
+        "Name": "sls-serverless-test-project-appsync-dev-ServerlessDeploymentBucketName"
+      }
+    },
+    "AwesomeappsyncGraphQlApiId": {
+      "Value": {
+        "Fn::GetAtt": [
+          "AwesomeappsyncGraphQlApi",
+          "ApiId"
+        ]
+      },
+      "Export": {
+        "Name": {
+          "Fn::Sub": "${AWS::StackName}-AwesomeappsyncGraphQlApiId"
+        }
+      }
+    },
+    "AwesomeappsyncGraphQlApiUrl": {
+      "Value": {
+        "Fn::GetAtt": [
+          "AwesomeappsyncGraphQlApi",
+          "GraphQLUrl"
+        ]
+      },
+      "Export": {
+        "Name": {
+          "Fn::Sub": "${AWS::StackName}-AwesomeappsyncGraphQlApiUrl"
+        }
+      }
+    }
+  }
+}

--- a/serverless-test-project-appsync/tests/snapshot/serverless-test-project-appsync-snapshot.test.ts
+++ b/serverless-test-project-appsync/tests/snapshot/serverless-test-project-appsync-snapshot.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'tap'
+import ServerlessPlugin from 'serverless-slic-watch-plugin/serverless-plugin'
+
+import inputTemplate from './fixtures/cloudformation-template-update-stack.json'
+import { createMockServerless } from 'test-utils/sls-test-utils'
+import type { ResourceType } from 'slic-watch-core'
+
+const logger = {}
+
+const pluginUtils = { log: logger }
+
+test('serverless-test-project-appsync snapshot', (t) => {
+  const mockServerless = createMockServerless(inputTemplate.Resources as ResourceType)
+  const plugin = new ServerlessPlugin(mockServerless, null, pluginUtils)
+  plugin.createSlicWatchResources()
+  const generatedTemplate = mockServerless.service.provider.compiledCloudFormationTemplate
+  t.matchSnapshot(generatedTemplate, 'serverless-test-project-appsync template')
+  t.end()
+})

--- a/serverless-test-project/tests/snapshot/fixtures/cloudformation-template-update-stack.json
+++ b/serverless-test-project/tests/snapshot/fixtures/cloudformation-template-update-stack.json
@@ -1,0 +1,1548 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "The AWS CloudFormation template for this Serverless application",
+  "Resources": {
+    "ServerlessDeploymentBucket": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            {
+              "ServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "AES256"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ServerlessDeploymentBucketPolicy": {
+      "Type": "AWS::S3::BucketPolicy",
+      "Properties": {
+        "Bucket": {
+          "Ref": "ServerlessDeploymentBucket"
+        },
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:*",
+              "Effect": "Deny",
+              "Principal": "*",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "ServerlessDeploymentBucket"
+                      },
+                      "/*"
+                    ]
+                  ]
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition"
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "ServerlessDeploymentBucket"
+                      }
+                    ]
+                  ]
+                }
+              ],
+              "Condition": {
+                "Bool": {
+                  "aws:SecureTransport": false
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "HelloLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/serverless-test-project-dev-hello"
+      }
+    },
+    "PingLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/serverless-test-project-dev-ping"
+      }
+    },
+    "ThrottlerLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/serverless-test-project-dev-throttler"
+      }
+    },
+    "DriveStreamLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/serverless-test-project-dev-driveStream"
+      }
+    },
+    "DriveQueueLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/serverless-test-project-dev-driveQueue"
+      }
+    },
+    "DriveTableLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/serverless-test-project-dev-driveTable"
+      }
+    },
+    "StreamProcessorLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/serverless-test-project-dev-streamProcessor"
+      }
+    },
+    "HttpGetterLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/serverless-test-project-dev-httpGetter"
+      }
+    },
+    "SubscriptionHandlerLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/serverless-test-project-dev-subscriptionHandler"
+      }
+    },
+    "EventsRuleLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/serverless-test-project-dev-eventsRule"
+      }
+    },
+    "IamRoleLambdaExecution": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRole"
+              ]
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": {
+              "Fn::Join": [
+                "-",
+                [
+                  "serverless-test-project",
+                  "dev",
+                  "lambda"
+                ]
+              ]
+            },
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "logs:CreateLogStream",
+                    "logs:CreateLogGroup",
+                    "logs:TagResource"
+                  ],
+                  "Resource": [
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/serverless-test-project-dev*:*"
+                    }
+                  ]
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "logs:PutLogEvents"
+                  ],
+                  "Resource": [
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/serverless-test-project-dev*:*:*"
+                    }
+                  ]
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "kinesis:GetRecords",
+                    "kinesis:GetShardIterator",
+                    "kinesis:DescribeStream",
+                    "kinesis:ListStreams"
+                  ],
+                  "Resource": [
+                    {
+                      "Fn::GetAtt": [
+                        "stream",
+                        "Arn"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "Path": "/",
+        "RoleName": {
+          "Fn::Join": [
+            "-",
+            [
+              "serverless-test-project",
+              "dev",
+              {
+                "Ref": "AWS::Region"
+              },
+              "lambdaRole"
+            ]
+          ]
+        }
+      }
+    },
+    "HelloLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip"
+        },
+        "Handler": "basic-handler.hello",
+        "Runtime": "nodejs18.x",
+        "FunctionName": "serverless-test-project-dev-hello",
+        "MemorySize": 1024,
+        "Timeout": 6,
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "HelloLogGroup"
+      ],
+      "Metadata": {
+        "slicWatch": {
+          "alarms": {
+            "Lambda": {
+              "Invocations": {
+                "Threshold": 2
+              }
+            }
+          }
+        }
+      }
+    },
+    "PingLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip"
+        },
+        "Handler": "basic-handler.hello",
+        "Runtime": "nodejs18.x",
+        "FunctionName": "serverless-test-project-dev-ping",
+        "MemorySize": 1024,
+        "Timeout": 6,
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "PingLogGroup"
+      ],
+      "Metadata": {
+        "slicWatch": {
+          "dashboard": {
+            "enabled": false
+          }
+        }
+      }
+    },
+    "ThrottlerLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip"
+        },
+        "Handler": "basic-handler.hello",
+        "Runtime": "nodejs18.x",
+        "FunctionName": "serverless-test-project-dev-throttler",
+        "MemorySize": 1024,
+        "Timeout": 6,
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        },
+        "ReservedConcurrentExecutions": 0
+      },
+      "DependsOn": [
+        "ThrottlerLogGroup"
+      ],
+      "Metadata": {
+        "slicWatch": {}
+      }
+    },
+    "DriveStreamLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip"
+        },
+        "Handler": "stream-test-handler.handleDrive",
+        "Runtime": "nodejs18.x",
+        "FunctionName": "serverless-test-project-dev-driveStream",
+        "MemorySize": 1024,
+        "Timeout": 6,
+        "Environment": {
+          "Variables": {
+            "STREAM_NAME": {
+              "Ref": "stream"
+            }
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "DriveStreamLogGroup"
+      ],
+      "Metadata": {
+        "slicWatch": {}
+      }
+    },
+    "DriveQueueLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip"
+        },
+        "Handler": "queue-test-handler.handleDrive",
+        "Runtime": "nodejs18.x",
+        "FunctionName": "serverless-test-project-dev-driveQueue",
+        "MemorySize": 1024,
+        "Timeout": 6,
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "DriveQueueLogGroup"
+      ],
+      "Metadata": {
+        "slicWatch": {}
+      }
+    },
+    "DriveTableLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip"
+        },
+        "Handler": "table-test-hander.handleDrive",
+        "Runtime": "nodejs18.x",
+        "FunctionName": "serverless-test-project-dev-driveTable",
+        "MemorySize": 1024,
+        "Timeout": 6,
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "DriveTableLogGroup"
+      ],
+      "Metadata": {
+        "slicWatch": {}
+      }
+    },
+    "StreamProcessorLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip"
+        },
+        "Handler": "stream-handler.handle",
+        "Runtime": "nodejs18.x",
+        "FunctionName": "serverless-test-project-dev-streamProcessor",
+        "MemorySize": 1024,
+        "Timeout": 6,
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "StreamProcessorLogGroup"
+      ],
+      "Metadata": {
+        "slicWatch": {}
+      }
+    },
+    "HttpGetterLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip"
+        },
+        "Handler": "apigw-handler.handleGet",
+        "Runtime": "nodejs18.x",
+        "FunctionName": "serverless-test-project-dev-httpGetter",
+        "MemorySize": 1024,
+        "Timeout": 30,
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "HttpGetterLogGroup"
+      ],
+      "Metadata": {
+        "slicWatch": {}
+      }
+    },
+    "SubscriptionHandlerLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip"
+        },
+        "Handler": "apigw-handler.handleSubscription",
+        "Runtime": "nodejs18.x",
+        "FunctionName": "serverless-test-project-dev-subscriptionHandler",
+        "MemorySize": 1024,
+        "Timeout": 30,
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "SubscriptionHandlerLogGroup"
+      ],
+      "Metadata": {
+        "slicWatch": {}
+      }
+    },
+    "EventsRuleLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip"
+        },
+        "Handler": "rule-handler.handleRule",
+        "Runtime": "nodejs18.x",
+        "FunctionName": "serverless-test-project-dev-eventsRule",
+        "MemorySize": 1024,
+        "Timeout": 6,
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "EventsRuleLogGroup"
+      ],
+      "Metadata": {
+        "slicWatch": {
+          "alarms": {
+            "Lambda": {
+              "enabled": false
+            }
+          }
+        }
+      }
+    },
+    "HelloLambdaVersioncvZrQjYr4FdYsM3CaTj5TKuOJmUjyL07tfIDVXBSw4": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "HelloLambdaFunction"
+        },
+        "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0="
+      }
+    },
+    "PingLambdaVersionSQcuddhSFqI0xKYCyuQTTJMvwrlKCB77CNQ16xyQ": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "PingLambdaFunction"
+        },
+        "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0="
+      }
+    },
+    "ThrottlerLambdaVersion0UeWLgxZYywcyV3gGiutpyCQJEbO6Gk8zSSOP7dMEps": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "ThrottlerLambdaFunction"
+        },
+        "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0="
+      }
+    },
+    "DriveStreamLambdaVersionsWkqlV7IV7mJdqIqQToVljMizTzZoDCso7qMazjI": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "DriveStreamLambdaFunction"
+        },
+        "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0="
+      }
+    },
+    "DriveQueueLambdaVersionTmzx8HCxfunJ3etrLOOYLg8zG05MzRauykeVpZFz8WY": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "DriveQueueLambdaFunction"
+        },
+        "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0="
+      }
+    },
+    "DriveTableLambdaVersionkqI0DCnUasgza04mnCpqj0q5vePTOojYtyi4hxfE3ME": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "DriveTableLambdaFunction"
+        },
+        "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0="
+      }
+    },
+    "StreamProcessorLambdaVersion24Kwch4oq5ogXKcIDJuLGB1qAJWt8aqgW43aCjKI": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "StreamProcessorLambdaFunction"
+        },
+        "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0="
+      }
+    },
+    "HttpGetterLambdaVersionvK2ALwc1DFqBccIyulxoBU3GveALO98nQc2xP94J8": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "HttpGetterLambdaFunction"
+        },
+        "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0="
+      }
+    },
+    "SubscriptionHandlerLambdaVersion4kKEYaIgWsMN0XYzRQn4VAailfQcZ23kdSSOKepfB4A": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "SubscriptionHandlerLambdaFunction"
+        },
+        "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0="
+      }
+    },
+    "EventsRuleLambdaVersionxBuN447jfeozyKD2CEV3oCIHhShTUOVe5XKOkBlbchQ": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "EventsRuleLambdaFunction"
+        },
+        "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0="
+      }
+    },
+    "WorkflowRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": {
+                  "Fn::Sub": "states.${AWS::Region}.amazonaws.com"
+                }
+              },
+              "Action": "sts:AssumeRole"
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": "dev-serverless-test-project-statemachine",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "lambda:InvokeFunction"
+                  ],
+                  "Resource": [
+                    {
+                      "Fn::GetAtt": [
+                        "PingLambdaFunction",
+                        "Arn"
+                      ]
+                    },
+                    {
+                      "Fn::Sub": [
+                        "${functionArn}:*",
+                        {
+                          "functionArn": {
+                            "Fn::GetAtt": [
+                              "PingLambdaFunction",
+                              "Arn"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "logs:CreateLogDelivery",
+                    "logs:GetLogDelivery",
+                    "logs:UpdateLogDelivery",
+                    "logs:DeleteLogDelivery",
+                    "logs:ListLogDeliveries",
+                    "logs:PutResourcePolicy",
+                    "logs:DescribeResourcePolicies",
+                    "logs:DescribeLogGroups"
+                  ],
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "ExpressWorkflowRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": {
+                  "Fn::Sub": "states.${AWS::Region}.amazonaws.com"
+                }
+              },
+              "Action": "sts:AssumeRole"
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": "dev-serverless-test-project-statemachine",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "lambda:InvokeFunction"
+                  ],
+                  "Resource": [
+                    {
+                      "Fn::GetAtt": [
+                        "PingLambdaFunction",
+                        "Arn"
+                      ]
+                    },
+                    {
+                      "Fn::Sub": [
+                        "${functionArn}:*",
+                        {
+                          "functionArn": {
+                            "Fn::GetAtt": [
+                              "PingLambdaFunction",
+                              "Arn"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "logs:CreateLogDelivery",
+                    "logs:GetLogDelivery",
+                    "logs:UpdateLogDelivery",
+                    "logs:DeleteLogDelivery",
+                    "logs:ListLogDeliveries",
+                    "logs:PutResourcePolicy",
+                    "logs:DescribeResourcePolicies",
+                    "logs:DescribeLogGroups"
+                  ],
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "Workflow": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Sub": [
+            "{\n  \"StartAt\": \"What Next?\",\n  \"States\": {\n    \"What Next?\": {\n      \"Type\": \"Choice\",\n      \"Choices\": [\n        {\n          \"Variable\": \"$.destination\",\n          \"StringEquals\": \"fail\",\n          \"Next\": \"Fail\"\n        },\n        {\n          \"Variable\": \"$.destination\",\n          \"StringEquals\": \"timeoutTask\",\n          \"Next\": \"TimeoutTask\"\n        },\n        {\n          \"Variable\": \"$.destination\",\n          \"StringEquals\": \"keepWaiting\",\n          \"Next\": \"KeepWaiting\"\n        }\n      ],\n      \"Default\": \"Succeed\"\n    },\n    \"TimeoutTask\": {\n      \"Type\": \"Task\",\n      \"TimeoutSeconds\": 1,\n      \"Resource\": \"${085edd942ce144c5bd80364a6e973e4d}\",\n      \"Parameters\": {\n        \"sleepSeconds\": 3\n      },\n      \"Next\": \"Succeed\"\n    },\n    \"KeepWaiting\": {\n      \"Type\": \"Wait\",\n      \"Seconds\": 1,\n      \"Next\": \"KeepWaiting\"\n    },\n    \"Fail\": {\n      \"Type\": \"Fail\"\n    },\n    \"Succeed\": {\n      \"Type\": \"Pass\",\n      \"End\": true\n    }\n  }\n}",
+            {
+              "085edd942ce144c5bd80364a6e973e4d": {
+                "Fn::GetAtt": [
+                  "PingLambdaFunction",
+                  "Arn"
+                ]
+              }
+            }
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "WorkflowRole",
+            "Arn"
+          ]
+        },
+        "LoggingConfiguration": {
+          "Level": "ALL",
+          "IncludeExecutionData": true,
+          "Destinations": [
+            {
+              "CloudWatchLogsLogGroup": {
+                "LogGroupArn": {
+                  "Fn::GetAtt": [
+                    "workflowLogGroup",
+                    "Arn"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "StateMachineName": "Workflow"
+      },
+      "DependsOn": [
+        "WorkflowRole"
+      ]
+    },
+    "ExpressWorkflow": {
+      "Type": "AWS::StepFunctions::StateMachine",
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Sub": [
+            "{\n  \"StartAt\": \"What Next?\",\n  \"States\": {\n    \"What Next?\": {\n      \"Type\": \"Choice\",\n      \"Choices\": [\n        {\n          \"Variable\": \"$.destination\",\n          \"StringEquals\": \"fail\",\n          \"Next\": \"Fail\"\n        },\n        {\n          \"Variable\": \"$.destination\",\n          \"StringEquals\": \"timeoutTask\",\n          \"Next\": \"TimeoutTask\"\n        },\n        {\n          \"Variable\": \"$.destination\",\n          \"StringEquals\": \"keepWaiting\",\n          \"Next\": \"KeepWaiting\"\n        }\n      ],\n      \"Default\": \"Succeed\"\n    },\n    \"TimeoutTask\": {\n      \"Type\": \"Task\",\n      \"TimeoutSeconds\": 1,\n      \"Resource\": \"${085edd942ce144c5bd80364a6e973e4d}\",\n      \"Parameters\": {\n        \"sleepSeconds\": 3\n      },\n      \"Next\": \"Succeed\"\n    },\n    \"KeepWaiting\": {\n      \"Type\": \"Wait\",\n      \"Seconds\": 1,\n      \"Next\": \"KeepWaiting\"\n    },\n    \"Fail\": {\n      \"Type\": \"Fail\"\n    },\n    \"Succeed\": {\n      \"Type\": \"Pass\",\n      \"End\": true\n    }\n  }\n}",
+            {
+              "085edd942ce144c5bd80364a6e973e4d": {
+                "Fn::GetAtt": [
+                  "PingLambdaFunction",
+                  "Arn"
+                ]
+              }
+            }
+          ]
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "ExpressWorkflowRole",
+            "Arn"
+          ]
+        },
+        "StateMachineType": "EXPRESS",
+        "LoggingConfiguration": {
+          "Level": "ALL",
+          "IncludeExecutionData": true,
+          "Destinations": [
+            {
+              "CloudWatchLogsLogGroup": {
+                "LogGroupArn": {
+                  "Fn::GetAtt": [
+                    "expressWorkflowLogGroup",
+                    "Arn"
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        "StateMachineName": "ExpressWorkflow"
+      },
+      "DependsOn": [
+        "ExpressWorkflowRole"
+      ]
+    },
+    "ApiGatewayRestApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Name": "dev-serverless-test-project",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "Policy": ""
+      }
+    },
+    "ApiGatewayResourceItem": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "ApiGatewayRestApi",
+            "RootResourceId"
+          ]
+        },
+        "PathPart": "item",
+        "RestApiId": {
+          "Ref": "ApiGatewayRestApi"
+        }
+      }
+    },
+    "ApiGatewayResourceSubscription": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "ApiGatewayRestApi",
+            "RootResourceId"
+          ]
+        },
+        "PathPart": "subscription",
+        "RestApiId": {
+          "Ref": "ApiGatewayRestApi"
+        }
+      }
+    },
+    "ApiGatewayMethodItemGet": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "GET",
+        "RequestParameters": {},
+        "ResourceId": {
+          "Ref": "ApiGatewayResourceItem"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayRestApi"
+        },
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "HttpGetterLambdaFunction",
+                    "Arn"
+                  ]
+                },
+                "/invocations"
+              ]
+            ]
+          }
+        },
+        "MethodResponses": []
+      },
+      "DependsOn": [
+        "HttpGetterLambdaPermissionApiGateway"
+      ]
+    },
+    "ApiGatewayMethodSubscriptionPost": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "POST",
+        "RequestParameters": {},
+        "ResourceId": {
+          "Ref": "ApiGatewayResourceSubscription"
+        },
+        "RestApiId": {
+          "Ref": "ApiGatewayRestApi"
+        },
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region"
+                },
+                ":lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "SubscriptionHandlerLambdaFunction",
+                    "Arn"
+                  ]
+                },
+                "/invocations"
+              ]
+            ]
+          }
+        },
+        "MethodResponses": []
+      },
+      "DependsOn": [
+        "SubscriptionHandlerLambdaPermissionApiGateway"
+      ]
+    },
+    "ApiGatewayDeployment1701242215363": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiGatewayRestApi"
+        },
+        "StageName": "dev"
+      },
+      "DependsOn": [
+        "ApiGatewayMethodItemGet",
+        "ApiGatewayMethodSubscriptionPost"
+      ]
+    },
+    "HttpGetterLambdaPermissionApiGateway": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "HttpGetterLambdaFunction",
+            "Arn"
+          ]
+        },
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region"
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":",
+              {
+                "Ref": "ApiGatewayRestApi"
+              },
+              "/*/*"
+            ]
+          ]
+        }
+      }
+    },
+    "SubscriptionHandlerLambdaPermissionApiGateway": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "SubscriptionHandlerLambdaFunction",
+            "Arn"
+          ]
+        },
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region"
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":",
+              {
+                "Ref": "ApiGatewayRestApi"
+              },
+              "/*/*"
+            ]
+          ]
+        }
+      }
+    },
+    "StreamProcessorEventSourceMappingKinesisStream": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "DependsOn": [
+        "IamRoleLambdaExecution"
+      ],
+      "Properties": {
+        "BatchSize": 10,
+        "Enabled": true,
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "stream",
+            "Arn"
+          ]
+        },
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "StreamProcessorLambdaFunction",
+            "Arn"
+          ]
+        },
+        "StartingPosition": "LATEST",
+        "MaximumRetryAttempts": 0
+      }
+    },
+    "ServerlesstestprojectdeveventsRulerule1EventBridgeRule": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "EventPattern": {
+          "detail-type": [
+            "Invoke Lambda Function"
+          ]
+        },
+        "Name": "serverless-test-project-dev-eventsRule-rule-1",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "EventsRuleLambdaFunction",
+                "Arn"
+              ]
+            },
+            "Id": "serverless-test-project-dev-eventsRule-rule-1-target",
+            "RetryPolicy": {
+              "MaximumEventAgeInSeconds": 60,
+              "MaximumRetryAttempts": 2
+            }
+          }
+        ]
+      }
+    },
+    "EventsRuleEventBridgeLambdaPermission1": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "EventsRuleLambdaFunction",
+            "Arn"
+          ]
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            ":",
+            [
+              "arn",
+              {
+                "Ref": "AWS::Partition"
+              },
+              "events",
+              {
+                "Ref": "AWS::Region"
+              },
+              {
+                "Ref": "AWS::AccountId"
+              },
+              {
+                "Fn::Join": [
+                  "/",
+                  [
+                    "rule",
+                    "serverless-test-project-dev-eventsRule-rule-1"
+                  ]
+                ]
+              }
+            ]
+          ]
+        }
+      }
+    },
+    "stream": {
+      "Type": "AWS::Kinesis::Stream",
+      "Properties": {
+        "Name": {
+          "Fn::Sub": "slic-watch-test-project-stream-${AWS::AccountId}-${AWS::Region}"
+        },
+        "ShardCount": 1
+      }
+    },
+    "bucket": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "BucketName": {
+          "Fn::Sub": "slic-watch-test-project-bucket-${AWS::AccountId}-${AWS::Region}"
+        }
+      }
+    },
+    "dataTable": {
+      "Type": "AWS::DynamoDB::Table",
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "TableName": "MyTable",
+        "ProvisionedThroughput": {
+          "ReadCapacityUnits": 1,
+          "WriteCapacityUnits": 1
+        },
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "pk",
+            "AttributeType": "S"
+          },
+          {
+            "AttributeName": "sk",
+            "AttributeType": "S"
+          },
+          {
+            "AttributeName": "gsi1pk",
+            "AttributeType": "S"
+          },
+          {
+            "AttributeName": "gsi1sk",
+            "AttributeType": "S"
+          },
+          {
+            "AttributeName": "timestamp",
+            "AttributeType": "N"
+          }
+        ],
+        "KeySchema": [
+          {
+            "AttributeName": "pk",
+            "KeyType": "HASH"
+          },
+          {
+            "AttributeName": "sk",
+            "KeyType": "RANGE"
+          }
+        ],
+        "GlobalSecondaryIndexes": [
+          {
+            "IndexName": "GSI1",
+            "ProvisionedThroughput": {
+              "ReadCapacityUnits": 1,
+              "WriteCapacityUnits": 1
+            },
+            "KeySchema": [
+              {
+                "AttributeName": "gsi1pk",
+                "KeyType": "HASH"
+              },
+              {
+                "AttributeName": "gsi1sk",
+                "KeyType": "RANGE"
+              }
+            ],
+            "Projection": {
+              "NonKeyAttributes": [
+                "address"
+              ],
+              "ProjectionType": "INCLUDE"
+            }
+          }
+        ],
+        "LocalSecondaryIndexes": [
+          {
+            "IndexName": "LSI1",
+            "KeySchema": [
+              {
+                "AttributeName": "pk",
+                "KeyType": "HASH"
+              },
+              {
+                "AttributeName": "timestamp",
+                "KeyType": "RANGE"
+              }
+            ],
+            "Projection": {
+              "NonKeyAttributes": [
+                "name"
+              ],
+              "ProjectionType": "INCLUDE"
+            }
+          }
+        ]
+      }
+    },
+    "regularQueue": {
+      "Type": "AWS::SQS::Queue",
+      "Properties": {
+        "QueueName": "SomeRegularQueue"
+      }
+    },
+    "fifoQueue": {
+      "Type": "AWS::SQS::Queue",
+      "Properties": {
+        "QueueName": "SomeFifoQueue.fifo",
+        "FifoQueue": true
+      }
+    },
+    "workflowLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "WorkflowLogs",
+        "RetentionInDays": 1
+      }
+    },
+    "expressWorkflowLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "ExpressWorkflowLogs",
+        "RetentionInDays": 1
+      }
+    },
+    "vpc": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "CidrBlock": "10.0.0.0/16"
+      }
+    },
+    "subnet": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "AvailabilityZone": "eu-west-1a",
+        "CidrBlock": "10.0.16.0/20",
+        "VpcId": {
+          "Ref": "vpc"
+        }
+      }
+    },
+    "ecsCluster": {
+      "Type": "AWS::ECS::Cluster",
+      "Properties": {
+        "ClusterName": "awesome-cluster"
+      }
+    },
+    "ecsService": {
+      "Type": "AWS::ECS::Service",
+      "Properties": {
+        "ServiceName": "awesome-service",
+        "Cluster": {
+          "Ref": "ecsCluster"
+        },
+        "DesiredCount": 0,
+        "LaunchType": "FARGATE",
+        "TaskDefinition": {
+          "Ref": "taskDef"
+        },
+        "NetworkConfiguration": {
+          "AwsvpcConfiguration": {
+            "AssignPublicIp": "ENABLED",
+            "SecurityGroups": [],
+            "Subnets": [
+              {
+                "Ref": "subnet"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "taskDef": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "Cpu": 256,
+        "Memory": 512,
+        "ContainerDefinitions": [
+          {
+            "Name": "busybox",
+            "Image": "busybox",
+            "Cpu": 256,
+            "EntryPoint": [
+              "sh",
+              "-c"
+            ],
+            "Memory": 512,
+            "Command": [
+              "/bin/sh -c \"while true; do echo Hello; sleep 10; done\""
+            ],
+            "Essential": true
+          }
+        ],
+        "NetworkMode": "awsvpc"
+      }
+    },
+    "topic": {
+      "Type": "AWS::SNS::Topic",
+      "Properties": {
+        "TopicName": {
+          "Fn::Sub": "slic-watch-test-project-topic-${AWS::AccountId}-${AWS::Region}"
+        }
+      }
+    },
+    "subscriptionTest": {
+      "Type": "AWS::SNS::Subscription",
+      "Properties": {
+        "Endpoint": {
+          "Fn::Sub": "https://${ApiGatewayRestApi}.execute-api.${AWS::Region}.amazonaws.com/dev/subscription"
+        },
+        "Protocol": "https",
+        "TopicArn": {
+          "Ref": "topic"
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "ServerlessDeploymentBucketName": {
+      "Value": {
+        "Ref": "ServerlessDeploymentBucket"
+      },
+      "Export": {
+        "Name": "sls-serverless-test-project-dev-ServerlessDeploymentBucketName"
+      }
+    },
+    "HelloLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "HelloLambdaVersioncvZrQjYr4FdYsM3CaTj5TKuOJmUjyL07tfIDVXBSw4"
+      },
+      "Export": {
+        "Name": "sls-serverless-test-project-dev-HelloLambdaFunctionQualifiedArn"
+      }
+    },
+    "PingLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "PingLambdaVersionSQcuddhSFqI0xKYCyuQTTJMvwrlKCB77CNQ16xyQ"
+      },
+      "Export": {
+        "Name": "sls-serverless-test-project-dev-PingLambdaFunctionQualifiedArn"
+      }
+    },
+    "ThrottlerLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "ThrottlerLambdaVersion0UeWLgxZYywcyV3gGiutpyCQJEbO6Gk8zSSOP7dMEps"
+      },
+      "Export": {
+        "Name": "sls-serverless-test-project-dev-ThrottlerLambdaFunctionQualifiedArn"
+      }
+    },
+    "DriveStreamLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "DriveStreamLambdaVersionsWkqlV7IV7mJdqIqQToVljMizTzZoDCso7qMazjI"
+      },
+      "Export": {
+        "Name": "sls-serverless-test-project-dev-DriveStreamLambdaFunctionQualifiedArn"
+      }
+    },
+    "DriveQueueLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "DriveQueueLambdaVersionTmzx8HCxfunJ3etrLOOYLg8zG05MzRauykeVpZFz8WY"
+      },
+      "Export": {
+        "Name": "sls-serverless-test-project-dev-DriveQueueLambdaFunctionQualifiedArn"
+      }
+    },
+    "DriveTableLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "DriveTableLambdaVersionkqI0DCnUasgza04mnCpqj0q5vePTOojYtyi4hxfE3ME"
+      },
+      "Export": {
+        "Name": "sls-serverless-test-project-dev-DriveTableLambdaFunctionQualifiedArn"
+      }
+    },
+    "StreamProcessorLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "StreamProcessorLambdaVersion24Kwch4oq5ogXKcIDJuLGB1qAJWt8aqgW43aCjKI"
+      },
+      "Export": {
+        "Name": "sls-serverless-test-project-dev-StreamProcessorLambdaFunctionQualifiedArn"
+      }
+    },
+    "HttpGetterLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "HttpGetterLambdaVersionvK2ALwc1DFqBccIyulxoBU3GveALO98nQc2xP94J8"
+      },
+      "Export": {
+        "Name": "sls-serverless-test-project-dev-HttpGetterLambdaFunctionQualifiedArn"
+      }
+    },
+    "SubscriptionHandlerLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "SubscriptionHandlerLambdaVersion4kKEYaIgWsMN0XYzRQn4VAailfQcZ23kdSSOKepfB4A"
+      },
+      "Export": {
+        "Name": "sls-serverless-test-project-dev-SubscriptionHandlerLambdaFunctionQualifiedArn"
+      }
+    },
+    "EventsRuleLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "EventsRuleLambdaVersionxBuN447jfeozyKD2CEV3oCIHhShTUOVe5XKOkBlbchQ"
+      },
+      "Export": {
+        "Name": "sls-serverless-test-project-dev-EventsRuleLambdaFunctionQualifiedArn"
+      }
+    },
+    "WorkflowArn": {
+      "Description": "Current StateMachine Arn",
+      "Value": {
+        "Ref": "Workflow"
+      },
+      "Export": {
+        "Name": "sls-serverless-test-project-dev-WorkflowArn"
+      }
+    },
+    "ExpressWorkflowArn": {
+      "Description": "Current StateMachine Arn",
+      "Value": {
+        "Ref": "ExpressWorkflow"
+      },
+      "Export": {
+        "Name": "sls-serverless-test-project-dev-ExpressWorkflowArn"
+      }
+    },
+    "ServiceEndpoint": {
+      "Description": "URL of the service endpoint",
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "ApiGatewayRestApi"
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region"
+            },
+            ".",
+            {
+              "Ref": "AWS::URLSuffix"
+            },
+            "/dev"
+          ]
+        ]
+      },
+      "Export": {
+        "Name": "sls-serverless-test-project-dev-ServiceEndpoint"
+      }
+    }
+  }
+}

--- a/serverless-test-project/tests/snapshot/serverless-test-project-snapshot.test.ts
+++ b/serverless-test-project/tests/snapshot/serverless-test-project-snapshot.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'tap'
+import ServerlessPlugin from 'serverless-slic-watch-plugin/serverless-plugin'
+
+import inputTemplate from './fixtures/cloudformation-template-update-stack.json'
+import { createMockServerless } from 'test-utils/sls-test-utils'
+import type { ResourceType } from 'slic-watch-core'
+
+const logger = {}
+
+const pluginUtils = { log: logger }
+
+test('serverless-test-project snapshot', (t) => {
+  const mockServerless = createMockServerless(inputTemplate.Resources as ResourceType)
+  const plugin = new ServerlessPlugin(mockServerless, null, pluginUtils)
+  plugin.createSlicWatchResources()
+  const generatedTemplate = mockServerless.service.provider.compiledCloudFormationTemplate
+  t.matchSnapshot(generatedTemplate, 'serverless-test-project template')
+  t.end()
+})

--- a/tap-snapshots/cdk-test-project/tests/snapshot/cdk-test-project-snapshot.test.ts.test.cjs
+++ b/tap-snapshots/cdk-test-project/tests/snapshot/cdk-test-project-snapshot.test.ts.test.cjs
@@ -1,0 +1,7502 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`cdk-test-project/tests/snapshot/cdk-test-project-snapshot.test.ts > TAP > cdk-test-project snapshot > ecsStack fragment 1`] = `
+Object {
+  "Metadata": Object {
+    "slicWatch": Object {
+      "alarms": Object {
+        "Lambda": Object {
+          "Invocations": Object {
+            "enabled": true,
+            "Threshold": 10,
+          },
+        },
+        "SQS": Object {
+          "AgeOfOldestMessage": Object {
+            "enabled": true,
+            "Statistic": "Maximum",
+            "Threshold": 60,
+          },
+          "InFlightMessagesPc": Object {
+            "Statistic": "Maximum",
+            "Threshold": 1,
+          },
+        },
+      },
+      "enabled": true,
+    },
+  },
+  "Outputs": Object {
+    "MyWebServerLoadBalancerDNSD1AFCC81": Object {
+      "Value": Object {
+        "Fn::GetAtt": Array [
+          "MyWebServerLB3B5FD3AB",
+          "DNSName",
+        ],
+      },
+    },
+    "MyWebServerServiceURLB0ED50F6": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "http://",
+            Object {
+              "Fn::GetAtt": Array [
+                "MyWebServerLB3B5FD3AB",
+                "DNSName",
+              ],
+            },
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "CDKMetadata": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/CDKMetadata/Default",
+      },
+      "Properties": Object {
+        "Analytics": "v2:deflate64:H4sIAAAAAAAA/31Ry27CMBD8Fu7GbTlUXCmlCAm1UYK4IsfZpgvBjux1EIry73WepLSqFGlnx+PsembG58/8cSIudiqT0zTDmJcRCXlinjqUIO0hF0RglOWLPM9QCkKttlokLyITSkLyJkwqCCIwBUpgkAlLKDOviBsFqrSY8fLv24YtP3/2Yx1aAtVpejw63/nJQGujXV5LRm3FQPqZEUhnkK6D5H9ilRqw9he9US2/z2V9tg+WLHCxXyJysQJq9AMKtSPYiTiDG3/jFtZqic3yg7gGq01Ql3dBa2/lRVxZYLCoXR1+vFF1CjAI2k26bkE+s68zKKpfbnnZhbIT9vQKn6iwH3nPaEUCva8j7i7Qxo4OZs6n0OTRwYqhOPMy1O17mxpo702zYIsqlunU77TV6eB7j6uq7j4c5Y5YCFY7047sccWUToAf7UPxNOf+m02OFnFqnCI8Aw/b+g3+NWTOyAIAAA==",
+      },
+      "Type": "AWS::CDK::Metadata",
+    },
+    "EcsDefaultClusterMnL3mNNYN926A5246": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Resource",
+      },
+      "Type": "AWS::ECS::Cluster",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpc7788A521": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/Resource",
+      },
+      "Properties": Object {
+        "CidrBlock": "10.0.0.0/16",
+        "EnableDnsHostnames": true,
+        "EnableDnsSupport": true,
+        "InstanceTenancy": "default",
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::VPC",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcIGW9C2C2B8F": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/IGW",
+      },
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::InternetGateway",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet1DefaultRouteA5ADF694": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet1/DefaultRoute",
+      },
+      "Properties": Object {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1NATGateway5E3732C1",
+        },
+        "RouteTableId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet1RouteTable4F1D2E36",
+        },
+      },
+      "Type": "AWS::EC2::Route",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet1RouteTable4F1D2E36": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet1/RouteTable",
+      },
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet1RouteTableAssociation34B92275": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet1/RouteTableAssociation",
+      },
+      "Properties": Object {
+        "RouteTableId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet1RouteTable4F1D2E36",
+        },
+        "SubnetId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet1Subnet075EFF4C",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet1Subnet075EFF4C": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet1/Subnet",
+      },
+      "Properties": Object {
+        "AvailabilityZone": Object {
+          "Fn::Select": Array [
+            0,
+            Object {
+              "Fn::GetAZs": "",
+            },
+          ],
+        },
+        "CidrBlock": "10.0.128.0/18",
+        "MapPublicIpOnLaunch": false,
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Private",
+          },
+          Object {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Private",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet2DefaultRoute20CE2D89": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet2/DefaultRoute",
+      },
+      "Properties": Object {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2NATGateway4C855E00",
+        },
+        "RouteTableId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet2RouteTableDCE46591",
+        },
+      },
+      "Type": "AWS::EC2::Route",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet2RouteTableAssociation111C622F": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet2/RouteTableAssociation",
+      },
+      "Properties": Object {
+        "RouteTableId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet2RouteTableDCE46591",
+        },
+        "SubnetId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet2SubnetE4CEDF73",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet2RouteTableDCE46591": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet2/RouteTable",
+      },
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet2",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet2SubnetE4CEDF73": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet2/Subnet",
+      },
+      "Properties": Object {
+        "AvailabilityZone": Object {
+          "Fn::Select": Array [
+            1,
+            Object {
+              "Fn::GetAZs": "",
+            },
+          ],
+        },
+        "CidrBlock": "10.0.192.0/18",
+        "MapPublicIpOnLaunch": false,
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Private",
+          },
+          Object {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Private",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PrivateSubnet2",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1DefaultRouteFF4E2178": Object {
+      "DependsOn": Array [
+        "EcsDefaultClusterMnL3mNNYNVpcVPCGW2447264E",
+      ],
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1/DefaultRoute",
+      },
+      "Properties": Object {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpcIGW9C2C2B8F",
+        },
+        "RouteTableId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1RouteTableA1FD6ACC",
+        },
+      },
+      "Type": "AWS::EC2::Route",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1EIP8704DB2F": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1/EIP",
+      },
+      "Properties": Object {
+        "Domain": "vpc",
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::EIP",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1NATGateway5E3732C1": Object {
+      "DependsOn": Array [
+        "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1DefaultRouteFF4E2178",
+        "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1RouteTableAssociation8B583A17",
+      ],
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1/NATGateway",
+      },
+      "Properties": Object {
+        "AllocationId": Object {
+          "Fn::GetAtt": Array [
+            "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1EIP8704DB2F",
+            "AllocationId",
+          ],
+        },
+        "SubnetId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1Subnet3C273B99",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::NatGateway",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1RouteTableA1FD6ACC": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1/RouteTable",
+      },
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1RouteTableAssociation8B583A17": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1/RouteTableAssociation",
+      },
+      "Properties": Object {
+        "RouteTableId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1RouteTableA1FD6ACC",
+        },
+        "SubnetId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1Subnet3C273B99",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1Subnet3C273B99": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1/Subnet",
+      },
+      "Properties": Object {
+        "AvailabilityZone": Object {
+          "Fn::Select": Array [
+            0,
+            Object {
+              "Fn::GetAZs": "",
+            },
+          ],
+        },
+        "CidrBlock": "10.0.0.0/18",
+        "MapPublicIpOnLaunch": true,
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Public",
+          },
+          Object {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Public",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2DefaultRouteB1375520": Object {
+      "DependsOn": Array [
+        "EcsDefaultClusterMnL3mNNYNVpcVPCGW2447264E",
+      ],
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2/DefaultRoute",
+      },
+      "Properties": Object {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpcIGW9C2C2B8F",
+        },
+        "RouteTableId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2RouteTable263DEAA5",
+        },
+      },
+      "Type": "AWS::EC2::Route",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2EIPF0764873": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2/EIP",
+      },
+      "Properties": Object {
+        "Domain": "vpc",
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::EIP",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2NATGateway4C855E00": Object {
+      "DependsOn": Array [
+        "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2DefaultRouteB1375520",
+        "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2RouteTableAssociation43E5803C",
+      ],
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2/NATGateway",
+      },
+      "Properties": Object {
+        "AllocationId": Object {
+          "Fn::GetAtt": Array [
+            "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2EIPF0764873",
+            "AllocationId",
+          ],
+        },
+        "SubnetId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2Subnet95FF715A",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2",
+          },
+        ],
+      },
+      "Type": "AWS::EC2::NatGateway",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2RouteTable263DEAA5": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2/RouteTable",
+      },
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521",
+        },
+      },
+      "Type": "AWS::EC2::RouteTable",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2RouteTableAssociation43E5803C": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2/RouteTableAssociation",
+      },
+      "Properties": Object {
+        "RouteTableId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2RouteTable263DEAA5",
+        },
+        "SubnetId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2Subnet95FF715A",
+        },
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2Subnet95FF715A": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2/Subnet",
+      },
+      "Properties": Object {
+        "AvailabilityZone": Object {
+          "Fn::Select": Array [
+            1,
+            Object {
+              "Fn::GetAZs": "",
+            },
+          ],
+        },
+        "CidrBlock": "10.0.64.0/18",
+        "MapPublicIpOnLaunch": true,
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "Public",
+          },
+          Object {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Public",
+          },
+          Object {
+            "Key": "Name",
+            "Value": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/PublicSubnet2",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "EcsDefaultClusterMnL3mNNYNVpcVPCGW2447264E": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/EcsDefaultClusterMnL3mNNYN/Vpc/VPCGW",
+      },
+      "Properties": Object {
+        "InternetGatewayId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpcIGW9C2C2B8F",
+        },
+        "VpcId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521",
+        },
+      },
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+    },
+    "MyWebServerLB3B5FD3AB": Object {
+      "DependsOn": Array [
+        "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1DefaultRouteFF4E2178",
+        "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1RouteTableAssociation8B583A17",
+        "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2DefaultRouteB1375520",
+        "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2RouteTableAssociation43E5803C",
+      ],
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/LB/Resource",
+      },
+      "Properties": Object {
+        "LoadBalancerAttributes": Array [
+          Object {
+            "Key": "deletion_protection.enabled",
+            "Value": "false",
+          },
+        ],
+        "Scheme": "internet-facing",
+        "SecurityGroups": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "MyWebServerLBSecurityGroup01B285AA",
+              "GroupId",
+            ],
+          },
+        ],
+        "Subnets": Array [
+          Object {
+            "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet1Subnet3C273B99",
+          },
+          Object {
+            "Ref": "EcsDefaultClusterMnL3mNNYNVpcPublicSubnet2Subnet95FF715A",
+          },
+        ],
+        "Type": "application",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "MyWebServerLBPublicListener03D7C493": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/LB/PublicListener/Resource",
+      },
+      "Properties": Object {
+        "DefaultActions": Array [
+          Object {
+            "TargetGroupArn": Object {
+              "Ref": "MyWebServerLBPublicListenerECSGroup5AB9F1C3",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": Object {
+          "Ref": "MyWebServerLB3B5FD3AB",
+        },
+        "Port": 80,
+        "Protocol": "HTTP",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+    },
+    "MyWebServerLBPublicListenerECSGroup5AB9F1C3": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/LB/PublicListener/ECSGroup/Resource",
+      },
+      "Properties": Object {
+        "Port": 80,
+        "Protocol": "HTTP",
+        "TargetGroupAttributes": Array [
+          Object {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "ip",
+        "VpcId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "MyWebServerLBSecurityGroup01B285AA": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/LB/SecurityGroup/Resource",
+      },
+      "Properties": Object {
+        "GroupDescription": "Automatically created Security Group for ELB CdkECSStackTestEuropeMyWebServerLBE298D4B6",
+        "SecurityGroupIngress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 80",
+            "FromPort": 80,
+            "IpProtocol": "tcp",
+            "ToPort": 80,
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "MyWebServerLBSecurityGrouptoCdkECSStackTestEuropeMyWebServerServiceSecurityGroup792A2ECD807CF0A9FB": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/LB/SecurityGroup/to CdkECSStackTestEuropeMyWebServerServiceSecurityGroup792A2ECD:80",
+      },
+      "Properties": Object {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "MyWebServerServiceSecurityGroup6788214A",
+            "GroupId",
+          ],
+        },
+        "FromPort": 80,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "MyWebServerLBSecurityGroup01B285AA",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 80,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "MyWebServerService2FE7341D": Object {
+      "DependsOn": Array [
+        "MyWebServerLBPublicListenerECSGroup5AB9F1C3",
+        "MyWebServerLBPublicListener03D7C493",
+        "MyWebServerTaskDefTaskRoleB23C17AA",
+      ],
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/Service/Service",
+      },
+      "Properties": Object {
+        "Cluster": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYN926A5246",
+        },
+        "DeploymentConfiguration": Object {
+          "MaximumPercent": 200,
+          "MinimumHealthyPercent": 50,
+        },
+        "EnableECSManagedTags": false,
+        "HealthCheckGracePeriodSeconds": 60,
+        "LaunchType": "FARGATE",
+        "LoadBalancers": Array [
+          Object {
+            "ContainerName": "web",
+            "ContainerPort": 80,
+            "TargetGroupArn": Object {
+              "Ref": "MyWebServerLBPublicListenerECSGroup5AB9F1C3",
+            },
+          },
+        ],
+        "NetworkConfiguration": Object {
+          "AwsvpcConfiguration": Object {
+            "AssignPublicIp": "DISABLED",
+            "SecurityGroups": Array [
+              Object {
+                "Fn::GetAtt": Array [
+                  "MyWebServerServiceSecurityGroup6788214A",
+                  "GroupId",
+                ],
+              },
+            ],
+            "Subnets": Array [
+              Object {
+                "Ref": "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet1Subnet075EFF4C",
+              },
+              Object {
+                "Ref": "EcsDefaultClusterMnL3mNNYNVpcPrivateSubnet2SubnetE4CEDF73",
+              },
+            ],
+          },
+        },
+        "TaskDefinition": Object {
+          "Ref": "MyWebServerTaskDef4CE825A0",
+        },
+      },
+      "Type": "AWS::ECS::Service",
+    },
+    "MyWebServerServiceSecurityGroup6788214A": Object {
+      "DependsOn": Array [
+        "MyWebServerTaskDefTaskRoleB23C17AA",
+      ],
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/Service/SecurityGroup/Resource",
+      },
+      "Properties": Object {
+        "GroupDescription": "CdkECSStackTest-Europe/MyWebServer/Service/SecurityGroup",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "EcsDefaultClusterMnL3mNNYNVpc7788A521",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "MyWebServerServiceSecurityGroupfromCdkECSStackTestEuropeMyWebServerLBSecurityGroup8823910380E44CF71E": Object {
+      "DependsOn": Array [
+        "MyWebServerTaskDefTaskRoleB23C17AA",
+      ],
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/Service/SecurityGroup/from CdkECSStackTestEuropeMyWebServerLBSecurityGroup88239103:80",
+      },
+      "Properties": Object {
+        "Description": "Load balancer to target",
+        "FromPort": 80,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "MyWebServerServiceSecurityGroup6788214A",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "MyWebServerLBSecurityGroup01B285AA",
+            "GroupId",
+          ],
+        },
+        "ToPort": 80,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "MyWebServerTaskDef4CE825A0": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/TaskDef/Resource",
+      },
+      "Properties": Object {
+        "ContainerDefinitions": Array [
+          Object {
+            "Essential": true,
+            "Image": "amazon/amazon-ecs-sample",
+            "LogConfiguration": Object {
+              "LogDriver": "awslogs",
+              "Options": Object {
+                "awslogs-group": Object {
+                  "Ref": "MyWebServerTaskDefwebLogGroupC6EE23D4",
+                },
+                "awslogs-region": "eu-west-1",
+                "awslogs-stream-prefix": "MyWebServer",
+              },
+            },
+            "Name": "web",
+            "PortMappings": Array [
+              Object {
+                "ContainerPort": 80,
+                "Protocol": "tcp",
+              },
+            ],
+          },
+        ],
+        "Cpu": "256",
+        "ExecutionRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "MyWebServerTaskDefExecutionRole3C69E361",
+            "Arn",
+          ],
+        },
+        "Family": "CdkECSStackTestEuropeMyWebServerTaskDef979012A1",
+        "Memory": "512",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": Array [
+          "FARGATE",
+        ],
+        "TaskRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "MyWebServerTaskDefTaskRoleB23C17AA",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "MyWebServerTaskDefExecutionRole3C69E361": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/TaskDef/ExecutionRole/Resource",
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "MyWebServerTaskDefExecutionRoleDefaultPolicy2AEB4329": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/TaskDef/ExecutionRole/DefaultPolicy/Resource",
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "MyWebServerTaskDefwebLogGroupC6EE23D4",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "MyWebServerTaskDefExecutionRoleDefaultPolicy2AEB4329",
+        "Roles": Array [
+          Object {
+            "Ref": "MyWebServerTaskDefExecutionRole3C69E361",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "MyWebServerTaskDefTaskRoleB23C17AA": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/TaskDef/TaskRole/Resource",
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "MyWebServerTaskDefwebLogGroupC6EE23D4": Object {
+      "DeletionPolicy": "Retain",
+      "Metadata": Object {
+        "aws:cdk:path": "CdkECSStackTest-Europe/MyWebServer/TaskDef/web/LogGroup/Resource",
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "slicWatchDashboard": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Sub": "{\\"start\\":\\"-PT3H\\",\\"widgets\\":[{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/ECS\\",\\"MemoryUtilization\\",\\"ServiceName\\",\\"\${MyWebServerService2FE7341D.Name}\\",\\"ClusterName\\",\\"\${EcsDefaultClusterMnL3mNNYN926A5246}\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\"ServiceName\\",\\"\${MyWebServerService2FE7341D.Name}\\",\\"ClusterName\\",\\"\${EcsDefaultClusterMnL3mNNYN926A5246}\\",{\\"stat\\":\\"Average\\"}]],\\"title\\":\\"ECS Service \${MyWebServerService2FE7341D.Name}\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":0},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_ELB_5XX_Count\\",\\"LoadBalancer\\",\\"\${MyWebServerLB3B5FD3AB.LoadBalancerFullName}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/ApplicationELB\\",\\"RejectedConnectionCount\\",\\"LoadBalancer\\",\\"\${MyWebServerLB3B5FD3AB.LoadBalancerFullName}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"ALB \${MyWebServerLB3B5FD3AB.LoadBalancerName}\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":0},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/ApplicationELB\\",\\"HTTPCode_Target_5XX_Count\\",\\"LoadBalancer\\",\\"\${MyWebServerLB3B5FD3AB.LoadBalancerFullName}\\",\\"TargetGroup\\",\\"\${MyWebServerLBPublicListenerECSGroup5AB9F1C3.TargetGroupFullName}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/ApplicationELB\\",\\"UnHealthyHostCount\\",\\"LoadBalancer\\",\\"\${MyWebServerLB3B5FD3AB.LoadBalancerFullName}\\",\\"TargetGroup\\",\\"\${MyWebServerLBPublicListenerECSGroup5AB9F1C3.TargetGroupFullName}\\",{\\"stat\\":\\"Average\\"}]],\\"title\\":\\"Target Group \${MyWebServerLB3B5FD3AB.LoadBalancerName}/\${MyWebServerLBPublicListenerECSGroup5AB9F1C3.TargetGroupName}\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":0}]}",
+        },
+        "DashboardName": Object {
+          "Fn::Sub": "\${AWS::StackName}-\${AWS::Region}-Dashboard",
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "slicWatchECSCPUAlarmMyWebServerService2FE7341D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "ECS CPUUtilization for \${MyWebServerService2FE7341D.Name} breaches 90",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "ECS_CPUAlarm_\${MyWebServerService2FE7341D.Name}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "ServiceName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "MyWebServerService2FE7341D",
+                "Name",
+              ],
+            },
+          },
+          Object {
+            "Name": "ClusterName",
+            "Value": Object {
+              "Ref": "EcsDefaultClusterMnL3mNNYN926A5246",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "CPUUtilization",
+        "Namespace": "AWS/ECS",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 90,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchECSMemoryAlarmMyWebServerService2FE7341D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "ECS MemoryUtilization for \${MyWebServerService2FE7341D.Name} breaches 90",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "ECS_MemoryAlarm_\${MyWebServerService2FE7341D.Name}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "ServiceName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "MyWebServerService2FE7341D",
+                "Name",
+              ],
+            },
+          },
+          Object {
+            "Name": "ClusterName",
+            "Value": Object {
+              "Ref": "EcsDefaultClusterMnL3mNNYN926A5246",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "MemoryUtilization",
+        "Namespace": "AWS/ECS",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 90,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLoadBalancerHTTPCodeELB5XXCountAlarmMyWebServerLB3B5FD3AB": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [],
+        "AlarmDescription": "LoadBalancer HTTPCodeELB5XXCount Sum for MyWebServerLB3B5FD3AB  breaches 0",
+        "AlarmName": "LoadBalancer_HTTPCodeELB5XXCountAlarm_MyWebServerLB3B5FD3AB",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "LoadBalancer",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "MyWebServerLB3B5FD3AB",
+                "LoadBalancerFullName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "HTTPCode_ELB_5XX_Count",
+        "Namespace": "AWS/ApplicationELB",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLoadBalancerHTTPCodeTarget5XXCountAlarmMyWebServerLBPublicListenerECSGroup5AB9F1C3": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [],
+        "AlarmDescription": "LoadBalancer HTTPCode_Target_5XX_Count Sum for MyWebServerLBPublicListenerECSGroup5AB9F1C3 breaches 0",
+        "AlarmName": "LoadBalancer_HTTPCodeTarget5XXCountAlarm_MyWebServerLBPublicListenerECSGroup5AB9F1C3",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TargetGroup",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "MyWebServerLBPublicListenerECSGroup5AB9F1C3",
+                "TargetGroupFullName",
+              ],
+            },
+          },
+          Object {
+            "Name": "LoadBalancer",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "MyWebServerLB3B5FD3AB",
+                "LoadBalancerFullName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "HTTPCode_Target_5XX_Count",
+        "Namespace": "AWS/ApplicationELB",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLoadBalancerRejectedConnectionCountAlarmMyWebServerLB3B5FD3AB": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [],
+        "AlarmDescription": "LoadBalancer RejectedConnectionCount Sum for MyWebServerLB3B5FD3AB  breaches 0",
+        "AlarmName": "LoadBalancer_RejectedConnectionCountAlarm_MyWebServerLB3B5FD3AB",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "LoadBalancer",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "MyWebServerLB3B5FD3AB",
+                "LoadBalancerFullName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "RejectedConnectionCount",
+        "Namespace": "AWS/ApplicationELB",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLoadBalancerUnHealthyHostCountAlarmMyWebServerLBPublicListenerECSGroup5AB9F1C3": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [],
+        "AlarmDescription": "LoadBalancer UnHealthyHostCount Average for MyWebServerLBPublicListenerECSGroup5AB9F1C3 breaches 0",
+        "AlarmName": "LoadBalancer_UnHealthyHostCountAlarm_MyWebServerLBPublicListenerECSGroup5AB9F1C3",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TargetGroup",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "MyWebServerLBPublicListenerECSGroup5AB9F1C3",
+                "TargetGroupFullName",
+              ],
+            },
+          },
+          Object {
+            "Name": "LoadBalancer",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "MyWebServerLB3B5FD3AB",
+                "LoadBalancerFullName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "UnHealthyHostCount",
+        "Namespace": "AWS/ApplicationELB",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+  "Transform": "SlicWatch-v3",
+}
+`
+
+exports[`cdk-test-project/tests/snapshot/cdk-test-project-snapshot.test.ts > TAP > cdk-test-project snapshot > generalEuStack fragment 1`] = `
+Object {
+  "Metadata": Object {
+    "slicWatch": Object {
+      "alarmActionsConfig": Object {
+        "alarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+      },
+      "alarms": Object {
+        "Lambda": Object {
+          "Invocations": Object {
+            "enabled": true,
+            "Threshold": 10,
+          },
+        },
+        "SQS": Object {
+          "AgeOfOldestMessage": Object {
+            "enabled": true,
+            "Statistic": "Maximum",
+            "Threshold": 60,
+          },
+          "InFlightMessagesPc": Object {
+            "Statistic": "Maximum",
+            "Threshold": 1,
+          },
+        },
+      },
+      "enabled": true,
+      "topicArn": "arn:aws:xxxxxx:mytopic",
+    },
+  },
+  "Outputs": Object {
+    "myapiEndpoint8EB17201": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "myapi162F20B8",
+            },
+            ".execute-api.eu-west-1.",
+            Object {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            Object {
+              "Ref": "myapiDeploymentStageprod329F21FF",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "CDKMetadata": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/CDKMetadata/Default",
+      },
+      "Properties": Object {
+        "Analytics": "v2:deflate64:H4sIAAAAAAAA/02Q30/DIBDH/5a9M9SZmL12Gp801rr3hdKzshaoPdhsGv53D5izCeE+9z24Xxu+feC3K3HGtWy6da9qPn84ITtG0mFGg3ze20FJ9vhpEgTWC103gs/P3kinrImhJZcwaoVIXmBKaD5XtocYiDYwvD8IRHDIi2jI5zsvO3A7gcDEoFrh4CwmPr+kQhWgKwaVEvxjIaX1xrEnGHo7aSAkdeHRFG2qmoG+Wj9KSEXK0f5Mf8olceZXcF+2iVKmwJrJCG0b2ste1HmOBIHBierQfip/Gc+n8b5Jevfgk5Yh3aXtlZyuYnZDuHbG0jpit8q08dmbd4N3y/YCM7YBfsSb092W09msjqjUeqRNKA28yvYXs0P/r9UBAAA=",
+      },
+      "Type": "AWS::CDK::Metadata",
+    },
+    "DeadLetterQueue9F481546": Object {
+      "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/DeadLetterQueue/Resource",
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DeadLetterQueuePolicyB1FB890C": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/DeadLetterQueue/Policy/Resource",
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sqs:SendMessage",
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:SourceArn": Object {
+                    "Fn::GetAtt": Array [
+                      "ruleF2C1DCDC",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "events.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "DeadLetterQueue9F481546",
+                  "Arn",
+                ],
+              },
+              "Sid": "AllowEventRuleCdkGeneralStackTestEuroperule6219EF60",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Queues": Array [
+          Object {
+            "Ref": "DeadLetterQueue9F481546",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::QueuePolicy",
+    },
+    "DriveQueueHandler9F657A00": Object {
+      "DependsOn": Array [
+        "DriveQueueHandlerServiceRoleD796850A",
+      ],
+      "Metadata": Object {
+        "aws:asset:is-bundled": false,
+        "aws:asset:path": "asset.03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640",
+        "aws:asset:property": "Code",
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/DriveQueueHandler/Resource",
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
+          },
+          "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip",
+        },
+        "Handler": "hello.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DriveQueueHandlerServiceRoleD796850A",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DriveQueueHandlerServiceRoleD796850A": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/DriveQueueHandler/ServiceRole/Resource",
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DriveStreamHandler62F1767B": Object {
+      "DependsOn": Array [
+        "DriveStreamHandlerServiceRoleD2BAFDD4",
+      ],
+      "Metadata": Object {
+        "aws:asset:is-bundled": false,
+        "aws:asset:path": "asset.03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640",
+        "aws:asset:property": "Code",
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/DriveStreamHandler/Resource",
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
+          },
+          "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip",
+        },
+        "Handler": "stream-test-handler.handleDrive",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DriveStreamHandlerServiceRoleD2BAFDD4",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DriveStreamHandlerServiceRoleD2BAFDD4": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/DriveStreamHandler/ServiceRole/Resource",
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DriveTableHandler119966B0": Object {
+      "DependsOn": Array [
+        "DriveTableHandlerServiceRoleDDA3FBE1",
+      ],
+      "Metadata": Object {
+        "aws:asset:is-bundled": false,
+        "aws:asset:path": "asset.03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640",
+        "aws:asset:property": "Code",
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/DriveTableHandler/Resource",
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
+          },
+          "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip",
+        },
+        "Handler": "hello.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DriveTableHandlerServiceRoleDDA3FBE1",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DriveTableHandlerServiceRoleDDA3FBE1": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/DriveTableHandler/ServiceRole/Resource",
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "HelloHandler2E4FBA4D": Object {
+      "DependsOn": Array [
+        "HelloHandlerServiceRole11EF7C63",
+      ],
+      "Metadata": Object {
+        "slicWatch": Object {
+          "alarms": Object {
+            "Lambda": Object {
+              "Invocations": Object {
+                "Threshold": 4,
+              },
+            },
+          },
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
+          },
+          "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip",
+        },
+        "Handler": "hello.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "HelloHandlerServiceRole11EF7C63",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "HelloHandlerServiceRole11EF7C63": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/HelloHandler/ServiceRole/Resource",
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "myapi162F20B8": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Resource",
+      },
+      "Properties": Object {
+        "Name": "myapi",
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "myapiAccountC3A4750C": Object {
+      "DeletionPolicy": "Retain",
+      "DependsOn": Array [
+        "myapi162F20B8",
+      ],
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Account",
+      },
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "myapiCloudWatchRoleEB425128",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "myapiANY111D56B7": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Default/ANY/Resource",
+      },
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:eu-west-1:lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "HelloHandler2E4FBA4D",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "myapi162F20B8",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": Object {
+          "Ref": "myapi162F20B8",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "myapiANYApiPermissionCdkGeneralStackTestEuropemyapi65F2E57FANYEF4BF8F6": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Default/ANY/ApiPermission.CdkGeneralStackTestEuropemyapi65F2E57F.ANY..",
+      },
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "HelloHandler2E4FBA4D",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:eu-west-1:",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "myapi162F20B8",
+              },
+              "/",
+              Object {
+                "Ref": "myapiDeploymentStageprod329F21FF",
+              },
+              "/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "myapiANYApiPermissionTestCdkGeneralStackTestEuropemyapi65F2E57FANY3EBCCF8C": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Default/ANY/ApiPermission.Test.CdkGeneralStackTestEuropemyapi65F2E57F.ANY..",
+      },
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "HelloHandler2E4FBA4D",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:eu-west-1:",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "myapi162F20B8",
+              },
+              "/test-invoke-stage/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "myapiCloudWatchRoleEB425128": Object {
+      "DeletionPolicy": "Retain",
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/CloudWatchRole/Resource",
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "myapiDeploymentB7EF8EB76dbd4bbbb18c5c458967fb55792b4830": Object {
+      "DependsOn": Array [
+        "myapiproxyANYDD7FCE64",
+        "myapiproxyB6DF4575",
+        "myapiANY111D56B7",
+      ],
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Deployment/Resource",
+      },
+      "Properties": Object {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": Object {
+          "Ref": "myapi162F20B8",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "myapiDeploymentStageprod329F21FF": Object {
+      "DependsOn": Array [
+        "myapiAccountC3A4750C",
+      ],
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/DeploymentStage.prod/Resource",
+      },
+      "Properties": Object {
+        "DeploymentId": Object {
+          "Ref": "myapiDeploymentB7EF8EB76dbd4bbbb18c5c458967fb55792b4830",
+        },
+        "RestApiId": Object {
+          "Ref": "myapi162F20B8",
+        },
+        "StageName": "prod",
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "myapiproxyANYApiPermissionCdkGeneralStackTestEuropemyapi65F2E57FANYproxyBDBDCB62": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Default/{proxy+}/ANY/ApiPermission.CdkGeneralStackTestEuropemyapi65F2E57F.ANY..{proxy+}",
+      },
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "HelloHandler2E4FBA4D",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:eu-west-1:",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "myapi162F20B8",
+              },
+              "/",
+              Object {
+                "Ref": "myapiDeploymentStageprod329F21FF",
+              },
+              "/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "myapiproxyANYApiPermissionTestCdkGeneralStackTestEuropemyapi65F2E57FANYproxyF17A09F1": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Default/{proxy+}/ANY/ApiPermission.Test.CdkGeneralStackTestEuropemyapi65F2E57F.ANY..{proxy+}",
+      },
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "HelloHandler2E4FBA4D",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:eu-west-1:",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "myapi162F20B8",
+              },
+              "/test-invoke-stage/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "myapiproxyANYDD7FCE64": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Default/{proxy+}/ANY/Resource",
+      },
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:eu-west-1:lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "HelloHandler2E4FBA4D",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "myapiproxyB6DF4575",
+        },
+        "RestApiId": Object {
+          "Ref": "myapi162F20B8",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "myapiproxyB6DF4575": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/myapi/Default/{proxy+}/Resource",
+      },
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "myapi162F20B8",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": Object {
+          "Ref": "myapi162F20B8",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "MyTopic86869434": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/MyTopic/Resource",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "PingHandler50068074": Object {
+      "DependsOn": Array [
+        "PingHandlerServiceRole46086423",
+      ],
+      "Metadata": Object {
+        "slicWatch": Object {
+          "dashboard": Object {
+            "enabled": false,
+          },
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
+          },
+          "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip",
+        },
+        "Handler": "hello.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "PingHandlerServiceRole46086423",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "PingHandlerServiceRole46086423": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/PingHandler/ServiceRole/Resource",
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ruleAllowEventRuleCdkGeneralStackTestEuropeHelloHandlerE25EBD9DD0F76E59": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/rule/AllowEventRuleCdkGeneralStackTestEuropeHelloHandlerE25EBD9D",
+      },
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "HelloHandler2E4FBA4D",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::GetAtt": Array [
+            "ruleF2C1DCDC",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "ruleF2C1DCDC": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/rule/Resource",
+      },
+      "Properties": Object {
+        "EventPattern": Object {
+          "source": Array [
+            "aws.ec2",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": Array [
+          Object {
+            "Arn": Object {
+              "Fn::GetAtt": Array [
+                "HelloHandler2E4FBA4D",
+                "Arn",
+              ],
+            },
+            "DeadLetterConfig": Object {
+              "Arn": Object {
+                "Fn::GetAtt": Array [
+                  "DeadLetterQueue9F481546",
+                  "Arn",
+                ],
+              },
+            },
+            "Id": "Target0",
+            "RetryPolicy": Object {
+              "MaximumEventAgeInSeconds": 7200,
+              "MaximumRetryAttempts": 2,
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "slicWatchApi4XXErrorAlarmmyapi": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "API Gateway 4XXError Average for myapi breaches 0.05",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "ApiGW_4XXError_myapi",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "myapi",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "4XXError",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchApi5XXErrorAlarmmyapi": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "API Gateway 5XXError Average for myapi breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "ApiGW_5XXError_myapi",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "myapi",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchApiLatencyAlarmmyapi": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "API Gateway Latency p99 for myapi breaches 5000",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "ApiGW_Latency_myapi",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "myapi",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "ExtendedStatistic": "p99",
+        "MetricName": "Latency",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [],
+        "Period": 60,
+        "Threshold": 5000,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchDashboard": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Sub": "{\\"start\\":\\"-PT3H\\",\\"widgets\\":[{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"5XXError API myapi\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":0},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/ApiGateway\\",\\"4XXError\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"4XXError API myapi\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":0},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/ApiGateway\\",\\"4XXError\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"p95\\"}]],\\"title\\":\\"Latency API myapi\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":0},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/ApiGateway\\",\\"4XXError\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"p95\\"}],[\\"AWS/ApiGateway\\",\\"Count\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"Count API myapi\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":6},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/DynamoDB\\",\\"ReadThrottleEvents\\",\\"TableName\\",\\"\${TableCD117FA1}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"ReadThrottleEvents Table \${TableCD117FA1}\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":6},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/DynamoDB\\",\\"ReadThrottleEvents\\",\\"TableName\\",\\"\${TableCD117FA1}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/DynamoDB\\",\\"WriteThrottleEvents\\",\\"TableName\\",\\"\${TableCD117FA1}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"WriteThrottleEvents Table \${TableCD117FA1}\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":6},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"\${ThrottlerHandler750A7C89}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"\${DriveStreamHandler62F1767B}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"\${DriveQueueHandler9F657A00}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"\${DriveTableHandler119966B0}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"Lambda Errors Sum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":12},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"\${ThrottlerHandler750A7C89}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"\${DriveStreamHandler62F1767B}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"\${DriveQueueHandler9F657A00}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"\${DriveTableHandler119966B0}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"Lambda Throttles Sum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":12},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${ThrottlerHandler750A7C89}\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${DriveStreamHandler62F1767B}\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${DriveQueueHandler9F657A00}\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${DriveTableHandler119966B0}\\",{\\"stat\\":\\"Average\\"}]],\\"title\\":\\"Lambda Duration Average per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":12},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"p95\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${ThrottlerHandler750A7C89}\\",{\\"stat\\":\\"p95\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${DriveStreamHandler62F1767B}\\",{\\"stat\\":\\"p95\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${DriveQueueHandler9F657A00}\\",{\\"stat\\":\\"p95\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${DriveTableHandler119966B0}\\",{\\"stat\\":\\"p95\\"}]],\\"title\\":\\"Lambda Duration p95 per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":18},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${ThrottlerHandler750A7C89}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${DriveStreamHandler62F1767B}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${DriveQueueHandler9F657A00}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${DriveTableHandler119966B0}\\",{\\"stat\\":\\"Maximum\\"}]],\\"title\\":\\"Lambda Duration Maximum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":18},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"\${ThrottlerHandler750A7C89}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"\${DriveStreamHandler62F1767B}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"\${DriveQueueHandler9F657A00}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"\${DriveTableHandler119966B0}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"Lambda Invocations Sum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":18},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"\${ThrottlerHandler750A7C89}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"\${DriveStreamHandler62F1767B}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"\${DriveQueueHandler9F657A00}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"\${DriveTableHandler119966B0}\\",{\\"stat\\":\\"Maximum\\"}]],\\"title\\":\\"Lambda ConcurrentExecutions Maximum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":24},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/SQS\\",\\"NumberOfMessagesSent\\",\\"QueueName\\",\\"\${DeadLetterQueue9F481546.QueueName}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/SQS\\",\\"NumberOfMessagesReceived\\",\\"QueueName\\",\\"\${DeadLetterQueue9F481546.QueueName}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/SQS\\",\\"NumberOfMessagesDeleted\\",\\"QueueName\\",\\"\${DeadLetterQueue9F481546.QueueName}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"Messages \${DeadLetterQueue9F481546.QueueName} SQS\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":24},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/SQS\\",\\"ApproximateAgeOfOldestMessage\\",\\"QueueName\\",\\"\${DeadLetterQueue9F481546.QueueName}\\",{\\"stat\\":\\"Maximum\\"}]],\\"title\\":\\"Oldest Message age \${DeadLetterQueue9F481546.QueueName} SQS\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":24},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/SQS\\",\\"ApproximateNumberOfMessagesVisible\\",\\"QueueName\\",\\"\${DeadLetterQueue9F481546.QueueName}\\",{\\"stat\\":\\"Maximum\\"}]],\\"title\\":\\"Messages in queue \${DeadLetterQueue9F481546.QueueName} SQS\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":30},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/SNS\\",\\"NumberOfNotificationsFilteredOut-InvalidAttributes\\",\\"TopicName\\",\\"\${MyTopic86869434.TopicName}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/SNS\\",\\"NumberOfNotificationsFailed\\",\\"TopicName\\",\\"\${MyTopic86869434.TopicName}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"SNS Topic \${MyTopic86869434.TopicName}\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":30},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Events\\",\\"FailedInvocations\\",\\"RuleName\\",\\"\${ruleF2C1DCDC}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Events\\",\\"ThrottledRules\\",\\"RuleName\\",\\"\${ruleF2C1DCDC}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Events\\",\\"Invocations\\",\\"RuleName\\",\\"\${ruleF2C1DCDC}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"EventBridge Rule \${ruleF2C1DCDC}\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":30}]}",
+        },
+        "DashboardName": Object {
+          "Fn::Sub": "\${AWS::StackName}-\${AWS::Region}-Dashboard",
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "slicWatchEventsFailedInvocationsAlarmRuleF2C1DCDC": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "EventBridge FailedInvocations for \${ruleF2C1DCDC} breaches 1",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Events_FailedInvocations_Alarm_\${ruleF2C1DCDC}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "RuleName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "ruleF2C1DCDC",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "FailedInvocations",
+        "Namespace": "AWS/Events",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchEventsThrottledRulesAlarmRuleF2C1DCDC": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "EventBridge ThrottledRules for \${ruleF2C1DCDC} breaches 1",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Events_ThrottledRules_Alarm_\${ruleF2C1DCDC}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "RuleName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "ruleF2C1DCDC",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ThrottledRules",
+        "Namespace": "AWS/Events",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmDriveQueueHandler9F657A00": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${DriveQueueHandler9F657A00} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${DriveQueueHandler9F657A00}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "DriveQueueHandler9F657A00",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmDriveStreamHandler62F1767B": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${DriveStreamHandler62F1767B} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${DriveStreamHandler62F1767B}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "DriveStreamHandler62F1767B",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmDriveTableHandler119966B0": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${DriveTableHandler119966B0} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${DriveTableHandler119966B0}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "DriveTableHandler119966B0",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmHelloHandler2E4FBA4D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${HelloHandler2E4FBA4D} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${HelloHandler2E4FBA4D}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "HelloHandler2E4FBA4D",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmPingHandler50068074": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${PingHandler50068074} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${PingHandler50068074}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "PingHandler50068074",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmThrottlerHandler750A7C89": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${ThrottlerHandler750A7C89} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${ThrottlerHandler750A7C89}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "ThrottlerHandler750A7C89",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmDriveQueueHandler9F657A00": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${DriveQueueHandler9F657A00} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${DriveQueueHandler9F657A00}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "DriveQueueHandler9F657A00",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmDriveStreamHandler62F1767B": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${DriveStreamHandler62F1767B} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${DriveStreamHandler62F1767B}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "DriveStreamHandler62F1767B",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmDriveTableHandler119966B0": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${DriveTableHandler119966B0} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${DriveTableHandler119966B0}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "DriveTableHandler119966B0",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmHelloHandler2E4FBA4D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${HelloHandler2E4FBA4D} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${HelloHandler2E4FBA4D}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "HelloHandler2E4FBA4D",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmPingHandler50068074": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${PingHandler50068074} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${PingHandler50068074}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "PingHandler50068074",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmThrottlerHandler750A7C89": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${ThrottlerHandler750A7C89} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${ThrottlerHandler750A7C89}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "ThrottlerHandler750A7C89",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmDriveQueueHandler9F657A00": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${DriveQueueHandler9F657A00} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${DriveQueueHandler9F657A00}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "DriveQueueHandler9F657A00",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmDriveStreamHandler62F1767B": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${DriveStreamHandler62F1767B} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${DriveStreamHandler62F1767B}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "DriveStreamHandler62F1767B",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmDriveTableHandler119966B0": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${DriveTableHandler119966B0} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${DriveTableHandler119966B0}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "DriveTableHandler119966B0",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmHelloHandler2E4FBA4D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${HelloHandler2E4FBA4D} breaches 4",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${HelloHandler2E4FBA4D}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "HelloHandler2E4FBA4D",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 4,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmPingHandler50068074": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${PingHandler50068074} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${PingHandler50068074}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "PingHandler50068074",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmThrottlerHandler750A7C89": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${ThrottlerHandler750A7C89} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${ThrottlerHandler750A7C89}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "ThrottlerHandler750A7C89",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmDriveQueueHandler9F657A00": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${DriveQueueHandler9F657A00} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${DriveQueueHandler9F657A00}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "DriveQueueHandler9F657A00",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "DriveQueueHandler9F657A00",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmDriveStreamHandler62F1767B": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${DriveStreamHandler62F1767B} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${DriveStreamHandler62F1767B}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "DriveStreamHandler62F1767B",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "DriveStreamHandler62F1767B",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmDriveTableHandler119966B0": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${DriveTableHandler119966B0} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${DriveTableHandler119966B0}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "DriveTableHandler119966B0",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "DriveTableHandler119966B0",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmHelloHandler2E4FBA4D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${HelloHandler2E4FBA4D} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${HelloHandler2E4FBA4D}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "HelloHandler2E4FBA4D",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "HelloHandler2E4FBA4D",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmPingHandler50068074": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${PingHandler50068074} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${PingHandler50068074}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "PingHandler50068074",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "PingHandler50068074",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmThrottlerHandler750A7C89": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${ThrottlerHandler750A7C89} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${ThrottlerHandler750A7C89}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "ThrottlerHandler750A7C89",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "ThrottlerHandler750A7C89",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchSNSNumberOfNotificationsFailedAlarmMyTopic86869434": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SNS NumberOfNotificationsFailed for \${MyTopic86869434.TopicName} breaches 1",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SNS_NumberOfNotificationsFailed_Alarm_\${MyTopic86869434.TopicName}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TopicName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "MyTopic86869434",
+                "TopicName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "NumberOfNotificationsFailed",
+        "Namespace": "AWS/SNS",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchSNSNumberOfNotificationsFilteredOutInvalidAttributesAlarmMyTopic86869434": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SNS NumberOfNotificationsFilteredOutInvalidAttributes for \${MyTopic86869434.TopicName} breaches 1",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SNS_NumberOfNotificationsFilteredOutInvalidAttributes_Alarm_\${MyTopic86869434.TopicName}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TopicName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "MyTopic86869434",
+                "TopicName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "NumberOfNotificationsFilteredOut-InvalidAttributes",
+        "Namespace": "AWS/SNS",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchSQSInFlightMsgsAlarmDeadLetterQueue9F481546": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SQS in-flight messages for \${DeadLetterQueue9F481546.QueueName} breaches 1200 (1% of the hard limit of 120000)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SQS_ApproximateNumberOfMessagesNotVisible_\${DeadLetterQueue9F481546.QueueName}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "DeadLetterQueue9F481546",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesNotVisible",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 1200,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchSQSOldestMsgAgeAlarmDeadLetterQueue9F481546": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SQS age of oldest message in the queue \${DeadLetterQueue9F481546.QueueName} breaches 60",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SQS_ApproximateAgeOfOldestMessage_\${DeadLetterQueue9F481546.QueueName}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "DeadLetterQueue9F481546",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateAgeOfOldestMessage",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 60,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchTableReadThrottleEventsAlarmTableCD117FA1": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DynamoDB Sum for \${TableCD117FA1} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DDB_ReadThrottleEvents_Alarm_\${TableCD117FA1}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TableName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "TableCD117FA1",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ReadThrottleEvents",
+        "Namespace": "AWS/DynamoDB",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchTableSystemErrorsAlarmTableCD117FA1": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DynamoDB Sum for \${TableCD117FA1} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DDB_SystemErrors_Alarm_\${TableCD117FA1}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TableName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "TableCD117FA1",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "SystemErrors",
+        "Namespace": "AWS/DynamoDB",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchTableUserErrorsAlarmTableCD117FA1": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DynamoDB Sum for \${TableCD117FA1} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DDB_UserErrors_Alarm_\${TableCD117FA1}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TableName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "TableCD117FA1",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "UserErrors",
+        "Namespace": "AWS/DynamoDB",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchTableWriteThrottleEventsAlarmTableCD117FA1": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DynamoDB Sum for \${TableCD117FA1} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DDB_WriteThrottleEvents_Alarm_\${TableCD117FA1}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TableName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "TableCD117FA1",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "WriteThrottleEvents",
+        "Namespace": "AWS/DynamoDB",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "TableCD117FA1": Object {
+      "DeletionPolicy": "Retain",
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/Table/Resource",
+      },
+      "Properties": Object {
+        "AttributeDefinitions": Array [
+          Object {
+            "AttributeName": "id",
+            "AttributeType": "S",
+          },
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "KeySchema": Array [
+          Object {
+            "AttributeName": "id",
+            "KeyType": "HASH",
+          },
+        ],
+      },
+      "Type": "AWS::DynamoDB::Table",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ThrottlerHandler750A7C89": Object {
+      "DependsOn": Array [
+        "ThrottlerHandlerServiceRoleA0481DAF",
+      ],
+      "Metadata": Object {
+        "aws:asset:is-bundled": false,
+        "aws:asset:path": "asset.03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640",
+        "aws:asset:property": "Code",
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/ThrottlerHandler/Resource",
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
+          },
+          "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip",
+        },
+        "Handler": "hello.handler",
+        "ReservedConcurrentExecutions": 0,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "ThrottlerHandlerServiceRoleA0481DAF",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ThrottlerHandlerServiceRoleA0481DAF": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-Europe/ThrottlerHandler/ServiceRole/Resource",
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+  "Transform": "SlicWatch-v3",
+}
+`
+
+exports[`cdk-test-project/tests/snapshot/cdk-test-project-snapshot.test.ts > TAP > cdk-test-project snapshot > generalUsStack fragment 1`] = `
+Object {
+  "Metadata": Object {
+    "slicWatch": Object {
+      "alarmActionsConfig": Object {
+        "alarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+      },
+      "alarms": Object {
+        "Lambda": Object {
+          "Invocations": Object {
+            "enabled": true,
+            "Threshold": 10,
+          },
+        },
+        "SQS": Object {
+          "AgeOfOldestMessage": Object {
+            "enabled": true,
+            "Statistic": "Maximum",
+            "Threshold": 60,
+          },
+          "InFlightMessagesPc": Object {
+            "Statistic": "Maximum",
+            "Threshold": 1,
+          },
+        },
+      },
+      "enabled": true,
+      "topicArn": "arn:aws:xxxxxx:mytopic",
+    },
+  },
+  "Outputs": Object {
+    "myapiEndpoint8EB17201": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "myapi162F20B8",
+            },
+            ".execute-api.us-east-1.",
+            Object {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            Object {
+              "Ref": "myapiDeploymentStageprod329F21FF",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "CDKMetadata": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/CDKMetadata/Default",
+      },
+      "Properties": Object {
+        "Analytics": "v2:deflate64:H4sIAAAAAAAA/02Q30/DIBDH/5a9M9SZmL12Gp801rr3hdKzshaoPdhsGv53D5izCeE+9z24Xxu+feC3K3HGtWy6da9qPn84ITtG0mFGg3ze20FJ9vhpEgTWC103gs/P3kinrImhJZcwaoVIXmBKaD5XtocYiDYwvD8IRHDIi2jI5zsvO3A7gcDEoFrh4CwmPr+kQhWgKwaVEvxjIaX1xrEnGHo7aSAkdeHRFG2qmoG+Wj9KSEXK0f5Mf8olceZXcF+2iVKmwJrJCG0b2ste1HmOBIHBierQfip/Gc+n8b5Jevfgk5Yh3aXtlZyuYnZDuHbG0jpit8q08dmbd4N3y/YCM7YBfsSb092W09msjqjUeqRNKA28yvYXs0P/r9UBAAA=",
+      },
+      "Type": "AWS::CDK::Metadata",
+    },
+    "DeadLetterQueue9F481546": Object {
+      "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/DeadLetterQueue/Resource",
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DeadLetterQueuePolicyB1FB890C": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/DeadLetterQueue/Policy/Resource",
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sqs:SendMessage",
+              "Condition": Object {
+                "ArnEquals": Object {
+                  "aws:SourceArn": Object {
+                    "Fn::GetAtt": Array [
+                      "ruleF2C1DCDC",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "events.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "DeadLetterQueue9F481546",
+                  "Arn",
+                ],
+              },
+              "Sid": "AllowEventRuleCdkGeneralStackTestUSruleB0D09E87",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Queues": Array [
+          Object {
+            "Ref": "DeadLetterQueue9F481546",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::QueuePolicy",
+    },
+    "DriveQueueHandler9F657A00": Object {
+      "DependsOn": Array [
+        "DriveQueueHandlerServiceRoleD796850A",
+      ],
+      "Metadata": Object {
+        "aws:asset:is-bundled": false,
+        "aws:asset:path": "asset.03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640",
+        "aws:asset:property": "Code",
+        "aws:cdk:path": "CdkGeneralStackTest-US/DriveQueueHandler/Resource",
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
+          },
+          "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip",
+        },
+        "Handler": "hello.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DriveQueueHandlerServiceRoleD796850A",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DriveQueueHandlerServiceRoleD796850A": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/DriveQueueHandler/ServiceRole/Resource",
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DriveStreamHandler62F1767B": Object {
+      "DependsOn": Array [
+        "DriveStreamHandlerServiceRoleD2BAFDD4",
+      ],
+      "Metadata": Object {
+        "aws:asset:is-bundled": false,
+        "aws:asset:path": "asset.03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640",
+        "aws:asset:property": "Code",
+        "aws:cdk:path": "CdkGeneralStackTest-US/DriveStreamHandler/Resource",
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
+          },
+          "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip",
+        },
+        "Handler": "stream-test-handler.handleDrive",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DriveStreamHandlerServiceRoleD2BAFDD4",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DriveStreamHandlerServiceRoleD2BAFDD4": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/DriveStreamHandler/ServiceRole/Resource",
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DriveTableHandler119966B0": Object {
+      "DependsOn": Array [
+        "DriveTableHandlerServiceRoleDDA3FBE1",
+      ],
+      "Metadata": Object {
+        "aws:asset:is-bundled": false,
+        "aws:asset:path": "asset.03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640",
+        "aws:asset:property": "Code",
+        "aws:cdk:path": "CdkGeneralStackTest-US/DriveTableHandler/Resource",
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
+          },
+          "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip",
+        },
+        "Handler": "hello.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DriveTableHandlerServiceRoleDDA3FBE1",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DriveTableHandlerServiceRoleDDA3FBE1": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/DriveTableHandler/ServiceRole/Resource",
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "HelloHandler2E4FBA4D": Object {
+      "DependsOn": Array [
+        "HelloHandlerServiceRole11EF7C63",
+      ],
+      "Metadata": Object {
+        "slicWatch": Object {
+          "alarms": Object {
+            "Lambda": Object {
+              "Invocations": Object {
+                "Threshold": 4,
+              },
+            },
+          },
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
+          },
+          "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip",
+        },
+        "Handler": "hello.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "HelloHandlerServiceRole11EF7C63",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "HelloHandlerServiceRole11EF7C63": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/HelloHandler/ServiceRole/Resource",
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "myapi162F20B8": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Resource",
+      },
+      "Properties": Object {
+        "Name": "myapi",
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "myapiAccountC3A4750C": Object {
+      "DeletionPolicy": "Retain",
+      "DependsOn": Array [
+        "myapi162F20B8",
+      ],
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Account",
+      },
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "myapiCloudWatchRoleEB425128",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "myapiANY111D56B7": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Default/ANY/Resource",
+      },
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:us-east-1:lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "HelloHandler2E4FBA4D",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "myapi162F20B8",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": Object {
+          "Ref": "myapi162F20B8",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "myapiANYApiPermissionCdkGeneralStackTestUSmyapi9E6CC024ANY52E5EFEE": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Default/ANY/ApiPermission.CdkGeneralStackTestUSmyapi9E6CC024.ANY..",
+      },
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "HelloHandler2E4FBA4D",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:us-east-1:",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "myapi162F20B8",
+              },
+              "/",
+              Object {
+                "Ref": "myapiDeploymentStageprod329F21FF",
+              },
+              "/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "myapiANYApiPermissionTestCdkGeneralStackTestUSmyapi9E6CC024ANY1136CBF8": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Default/ANY/ApiPermission.Test.CdkGeneralStackTestUSmyapi9E6CC024.ANY..",
+      },
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "HelloHandler2E4FBA4D",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:us-east-1:",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "myapi162F20B8",
+              },
+              "/test-invoke-stage/*/",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "myapiCloudWatchRoleEB425128": Object {
+      "DeletionPolicy": "Retain",
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/myapi/CloudWatchRole/Resource",
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "myapiDeploymentB7EF8EB7fea2aa51ab5416f81a0b318c3a85d817": Object {
+      "DependsOn": Array [
+        "myapiproxyANYDD7FCE64",
+        "myapiproxyB6DF4575",
+        "myapiANY111D56B7",
+      ],
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Deployment/Resource",
+      },
+      "Properties": Object {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": Object {
+          "Ref": "myapi162F20B8",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "myapiDeploymentStageprod329F21FF": Object {
+      "DependsOn": Array [
+        "myapiAccountC3A4750C",
+      ],
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/myapi/DeploymentStage.prod/Resource",
+      },
+      "Properties": Object {
+        "DeploymentId": Object {
+          "Ref": "myapiDeploymentB7EF8EB7fea2aa51ab5416f81a0b318c3a85d817",
+        },
+        "RestApiId": Object {
+          "Ref": "myapi162F20B8",
+        },
+        "StageName": "prod",
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "myapiproxyANYApiPermissionCdkGeneralStackTestUSmyapi9E6CC024ANYproxy61FC0812": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Default/{proxy+}/ANY/ApiPermission.CdkGeneralStackTestUSmyapi9E6CC024.ANY..{proxy+}",
+      },
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "HelloHandler2E4FBA4D",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:us-east-1:",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "myapi162F20B8",
+              },
+              "/",
+              Object {
+                "Ref": "myapiDeploymentStageprod329F21FF",
+              },
+              "/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "myapiproxyANYApiPermissionTestCdkGeneralStackTestUSmyapi9E6CC024ANYproxy352B4E19": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Default/{proxy+}/ANY/ApiPermission.Test.CdkGeneralStackTestUSmyapi9E6CC024.ANY..{proxy+}",
+      },
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "HelloHandler2E4FBA4D",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:us-east-1:",
+              Object {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              Object {
+                "Ref": "myapi162F20B8",
+              },
+              "/test-invoke-stage/*/*",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "myapiproxyANYDD7FCE64": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Default/{proxy+}/ANY/Resource",
+      },
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:us-east-1:lambda:path/2015-03-31/functions/",
+                Object {
+                  "Fn::GetAtt": Array [
+                    "HelloHandler2E4FBA4D",
+                    "Arn",
+                  ],
+                },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+        "ResourceId": Object {
+          "Ref": "myapiproxyB6DF4575",
+        },
+        "RestApiId": Object {
+          "Ref": "myapi162F20B8",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "myapiproxyB6DF4575": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/myapi/Default/{proxy+}/Resource",
+      },
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "myapi162F20B8",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": Object {
+          "Ref": "myapi162F20B8",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "MyTopic86869434": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/MyTopic/Resource",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "PingHandler50068074": Object {
+      "DependsOn": Array [
+        "PingHandlerServiceRole46086423",
+      ],
+      "Metadata": Object {
+        "slicWatch": Object {
+          "dashboard": Object {
+            "enabled": false,
+          },
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
+          },
+          "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip",
+        },
+        "Handler": "hello.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "PingHandlerServiceRole46086423",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "PingHandlerServiceRole46086423": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/PingHandler/ServiceRole/Resource",
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ruleAllowEventRuleCdkGeneralStackTestUSHelloHandlerC75B8B54C6DD839C": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/rule/AllowEventRuleCdkGeneralStackTestUSHelloHandlerC75B8B54",
+      },
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "HelloHandler2E4FBA4D",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::GetAtt": Array [
+            "ruleF2C1DCDC",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "ruleF2C1DCDC": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/rule/Resource",
+      },
+      "Properties": Object {
+        "EventPattern": Object {
+          "source": Array [
+            "aws.ec2",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": Array [
+          Object {
+            "Arn": Object {
+              "Fn::GetAtt": Array [
+                "HelloHandler2E4FBA4D",
+                "Arn",
+              ],
+            },
+            "DeadLetterConfig": Object {
+              "Arn": Object {
+                "Fn::GetAtt": Array [
+                  "DeadLetterQueue9F481546",
+                  "Arn",
+                ],
+              },
+            },
+            "Id": "Target0",
+            "RetryPolicy": Object {
+              "MaximumEventAgeInSeconds": 7200,
+              "MaximumRetryAttempts": 2,
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "slicWatchApi4XXErrorAlarmmyapi": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "API Gateway 4XXError Average for myapi breaches 0.05",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "ApiGW_4XXError_myapi",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "myapi",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "4XXError",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchApi5XXErrorAlarmmyapi": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "API Gateway 5XXError Average for myapi breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "ApiGW_5XXError_myapi",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "myapi",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchApiLatencyAlarmmyapi": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "API Gateway Latency p99 for myapi breaches 5000",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "ApiGW_Latency_myapi",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "myapi",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "ExtendedStatistic": "p99",
+        "MetricName": "Latency",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [],
+        "Period": 60,
+        "Threshold": 5000,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchDashboard": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Sub": "{\\"start\\":\\"-PT3H\\",\\"widgets\\":[{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"5XXError API myapi\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":0},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/ApiGateway\\",\\"4XXError\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"4XXError API myapi\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":0},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/ApiGateway\\",\\"4XXError\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"p95\\"}]],\\"title\\":\\"Latency API myapi\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":0},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/ApiGateway\\",\\"4XXError\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"p95\\"}],[\\"AWS/ApiGateway\\",\\"Count\\",\\"ApiName\\",\\"myapi\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"Count API myapi\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":6},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/DynamoDB\\",\\"ReadThrottleEvents\\",\\"TableName\\",\\"\${TableCD117FA1}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"ReadThrottleEvents Table \${TableCD117FA1}\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":6},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/DynamoDB\\",\\"ReadThrottleEvents\\",\\"TableName\\",\\"\${TableCD117FA1}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/DynamoDB\\",\\"WriteThrottleEvents\\",\\"TableName\\",\\"\${TableCD117FA1}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"WriteThrottleEvents Table \${TableCD117FA1}\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":6},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"\${ThrottlerHandler750A7C89}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"\${DriveStreamHandler62F1767B}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"\${DriveQueueHandler9F657A00}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"\${DriveTableHandler119966B0}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"Lambda Errors Sum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":12},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"\${ThrottlerHandler750A7C89}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"\${DriveStreamHandler62F1767B}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"\${DriveQueueHandler9F657A00}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"\${DriveTableHandler119966B0}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"Lambda Throttles Sum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":12},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${ThrottlerHandler750A7C89}\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${DriveStreamHandler62F1767B}\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${DriveQueueHandler9F657A00}\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${DriveTableHandler119966B0}\\",{\\"stat\\":\\"Average\\"}]],\\"title\\":\\"Lambda Duration Average per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":12},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"p95\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${ThrottlerHandler750A7C89}\\",{\\"stat\\":\\"p95\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${DriveStreamHandler62F1767B}\\",{\\"stat\\":\\"p95\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${DriveQueueHandler9F657A00}\\",{\\"stat\\":\\"p95\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${DriveTableHandler119966B0}\\",{\\"stat\\":\\"p95\\"}]],\\"title\\":\\"Lambda Duration p95 per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":18},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${ThrottlerHandler750A7C89}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${DriveStreamHandler62F1767B}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${DriveQueueHandler9F657A00}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${DriveTableHandler119966B0}\\",{\\"stat\\":\\"Maximum\\"}]],\\"title\\":\\"Lambda Duration Maximum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":18},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"\${ThrottlerHandler750A7C89}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"\${DriveStreamHandler62F1767B}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"\${DriveQueueHandler9F657A00}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"\${DriveTableHandler119966B0}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"Lambda Invocations Sum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":18},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"\${ThrottlerHandler750A7C89}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"\${DriveStreamHandler62F1767B}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"\${DriveQueueHandler9F657A00}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"\${DriveTableHandler119966B0}\\",{\\"stat\\":\\"Maximum\\"}]],\\"title\\":\\"Lambda ConcurrentExecutions Maximum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":24},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/SQS\\",\\"NumberOfMessagesSent\\",\\"QueueName\\",\\"\${DeadLetterQueue9F481546.QueueName}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/SQS\\",\\"NumberOfMessagesReceived\\",\\"QueueName\\",\\"\${DeadLetterQueue9F481546.QueueName}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/SQS\\",\\"NumberOfMessagesDeleted\\",\\"QueueName\\",\\"\${DeadLetterQueue9F481546.QueueName}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"Messages \${DeadLetterQueue9F481546.QueueName} SQS\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":24},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/SQS\\",\\"ApproximateAgeOfOldestMessage\\",\\"QueueName\\",\\"\${DeadLetterQueue9F481546.QueueName}\\",{\\"stat\\":\\"Maximum\\"}]],\\"title\\":\\"Oldest Message age \${DeadLetterQueue9F481546.QueueName} SQS\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":24},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/SQS\\",\\"ApproximateNumberOfMessagesVisible\\",\\"QueueName\\",\\"\${DeadLetterQueue9F481546.QueueName}\\",{\\"stat\\":\\"Maximum\\"}]],\\"title\\":\\"Messages in queue \${DeadLetterQueue9F481546.QueueName} SQS\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":30},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/SNS\\",\\"NumberOfNotificationsFilteredOut-InvalidAttributes\\",\\"TopicName\\",\\"\${MyTopic86869434.TopicName}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/SNS\\",\\"NumberOfNotificationsFailed\\",\\"TopicName\\",\\"\${MyTopic86869434.TopicName}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"SNS Topic \${MyTopic86869434.TopicName}\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":30},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Events\\",\\"FailedInvocations\\",\\"RuleName\\",\\"\${ruleF2C1DCDC}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Events\\",\\"ThrottledRules\\",\\"RuleName\\",\\"\${ruleF2C1DCDC}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Events\\",\\"Invocations\\",\\"RuleName\\",\\"\${ruleF2C1DCDC}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"EventBridge Rule \${ruleF2C1DCDC}\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":30}]}",
+        },
+        "DashboardName": Object {
+          "Fn::Sub": "\${AWS::StackName}-\${AWS::Region}-Dashboard",
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "slicWatchEventsFailedInvocationsAlarmRuleF2C1DCDC": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "EventBridge FailedInvocations for \${ruleF2C1DCDC} breaches 1",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Events_FailedInvocations_Alarm_\${ruleF2C1DCDC}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "RuleName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "ruleF2C1DCDC",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "FailedInvocations",
+        "Namespace": "AWS/Events",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchEventsThrottledRulesAlarmRuleF2C1DCDC": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "EventBridge ThrottledRules for \${ruleF2C1DCDC} breaches 1",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Events_ThrottledRules_Alarm_\${ruleF2C1DCDC}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "RuleName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "ruleF2C1DCDC",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ThrottledRules",
+        "Namespace": "AWS/Events",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmDriveQueueHandler9F657A00": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${DriveQueueHandler9F657A00} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${DriveQueueHandler9F657A00}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "DriveQueueHandler9F657A00",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmDriveStreamHandler62F1767B": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${DriveStreamHandler62F1767B} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${DriveStreamHandler62F1767B}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "DriveStreamHandler62F1767B",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmDriveTableHandler119966B0": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${DriveTableHandler119966B0} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${DriveTableHandler119966B0}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "DriveTableHandler119966B0",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmHelloHandler2E4FBA4D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${HelloHandler2E4FBA4D} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${HelloHandler2E4FBA4D}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "HelloHandler2E4FBA4D",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmPingHandler50068074": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${PingHandler50068074} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${PingHandler50068074}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "PingHandler50068074",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmThrottlerHandler750A7C89": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${ThrottlerHandler750A7C89} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${ThrottlerHandler750A7C89}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "ThrottlerHandler750A7C89",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmDriveQueueHandler9F657A00": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${DriveQueueHandler9F657A00} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${DriveQueueHandler9F657A00}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "DriveQueueHandler9F657A00",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmDriveStreamHandler62F1767B": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${DriveStreamHandler62F1767B} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${DriveStreamHandler62F1767B}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "DriveStreamHandler62F1767B",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmDriveTableHandler119966B0": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${DriveTableHandler119966B0} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${DriveTableHandler119966B0}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "DriveTableHandler119966B0",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmHelloHandler2E4FBA4D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${HelloHandler2E4FBA4D} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${HelloHandler2E4FBA4D}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "HelloHandler2E4FBA4D",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmPingHandler50068074": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${PingHandler50068074} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${PingHandler50068074}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "PingHandler50068074",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmThrottlerHandler750A7C89": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${ThrottlerHandler750A7C89} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${ThrottlerHandler750A7C89}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "ThrottlerHandler750A7C89",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmDriveQueueHandler9F657A00": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${DriveQueueHandler9F657A00} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${DriveQueueHandler9F657A00}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "DriveQueueHandler9F657A00",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmDriveStreamHandler62F1767B": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${DriveStreamHandler62F1767B} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${DriveStreamHandler62F1767B}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "DriveStreamHandler62F1767B",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmDriveTableHandler119966B0": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${DriveTableHandler119966B0} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${DriveTableHandler119966B0}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "DriveTableHandler119966B0",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmHelloHandler2E4FBA4D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${HelloHandler2E4FBA4D} breaches 4",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${HelloHandler2E4FBA4D}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "HelloHandler2E4FBA4D",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 4,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmPingHandler50068074": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${PingHandler50068074} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${PingHandler50068074}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "PingHandler50068074",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmThrottlerHandler750A7C89": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${ThrottlerHandler750A7C89} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${ThrottlerHandler750A7C89}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "ThrottlerHandler750A7C89",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmDriveQueueHandler9F657A00": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${DriveQueueHandler9F657A00} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${DriveQueueHandler9F657A00}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "DriveQueueHandler9F657A00",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "DriveQueueHandler9F657A00",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmDriveStreamHandler62F1767B": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${DriveStreamHandler62F1767B} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${DriveStreamHandler62F1767B}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "DriveStreamHandler62F1767B",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "DriveStreamHandler62F1767B",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmDriveTableHandler119966B0": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${DriveTableHandler119966B0} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${DriveTableHandler119966B0}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "DriveTableHandler119966B0",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "DriveTableHandler119966B0",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmHelloHandler2E4FBA4D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${HelloHandler2E4FBA4D} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${HelloHandler2E4FBA4D}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "HelloHandler2E4FBA4D",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "HelloHandler2E4FBA4D",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmPingHandler50068074": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${PingHandler50068074} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${PingHandler50068074}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "PingHandler50068074",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "PingHandler50068074",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmThrottlerHandler750A7C89": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${ThrottlerHandler750A7C89} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${ThrottlerHandler750A7C89}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "ThrottlerHandler750A7C89",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "ThrottlerHandler750A7C89",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchSNSNumberOfNotificationsFailedAlarmMyTopic86869434": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SNS NumberOfNotificationsFailed for \${MyTopic86869434.TopicName} breaches 1",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SNS_NumberOfNotificationsFailed_Alarm_\${MyTopic86869434.TopicName}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TopicName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "MyTopic86869434",
+                "TopicName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "NumberOfNotificationsFailed",
+        "Namespace": "AWS/SNS",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchSNSNumberOfNotificationsFilteredOutInvalidAttributesAlarmMyTopic86869434": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SNS NumberOfNotificationsFilteredOutInvalidAttributes for \${MyTopic86869434.TopicName} breaches 1",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SNS_NumberOfNotificationsFilteredOutInvalidAttributes_Alarm_\${MyTopic86869434.TopicName}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TopicName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "MyTopic86869434",
+                "TopicName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "NumberOfNotificationsFilteredOut-InvalidAttributes",
+        "Namespace": "AWS/SNS",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchSQSInFlightMsgsAlarmDeadLetterQueue9F481546": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SQS in-flight messages for \${DeadLetterQueue9F481546.QueueName} breaches 1200 (1% of the hard limit of 120000)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SQS_ApproximateNumberOfMessagesNotVisible_\${DeadLetterQueue9F481546.QueueName}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "DeadLetterQueue9F481546",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesNotVisible",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 1200,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchSQSOldestMsgAgeAlarmDeadLetterQueue9F481546": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SQS age of oldest message in the queue \${DeadLetterQueue9F481546.QueueName} breaches 60",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SQS_ApproximateAgeOfOldestMessage_\${DeadLetterQueue9F481546.QueueName}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "DeadLetterQueue9F481546",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateAgeOfOldestMessage",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 60,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchTableReadThrottleEventsAlarmTableCD117FA1": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DynamoDB Sum for \${TableCD117FA1} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DDB_ReadThrottleEvents_Alarm_\${TableCD117FA1}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TableName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "TableCD117FA1",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ReadThrottleEvents",
+        "Namespace": "AWS/DynamoDB",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchTableSystemErrorsAlarmTableCD117FA1": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DynamoDB Sum for \${TableCD117FA1} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DDB_SystemErrors_Alarm_\${TableCD117FA1}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TableName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "TableCD117FA1",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "SystemErrors",
+        "Namespace": "AWS/DynamoDB",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchTableUserErrorsAlarmTableCD117FA1": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DynamoDB Sum for \${TableCD117FA1} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DDB_UserErrors_Alarm_\${TableCD117FA1}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TableName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "TableCD117FA1",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "UserErrors",
+        "Namespace": "AWS/DynamoDB",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchTableWriteThrottleEventsAlarmTableCD117FA1": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MyTopic86869434",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DynamoDB Sum for \${TableCD117FA1} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DDB_WriteThrottleEvents_Alarm_\${TableCD117FA1}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TableName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "TableCD117FA1",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "WriteThrottleEvents",
+        "Namespace": "AWS/DynamoDB",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "TableCD117FA1": Object {
+      "DeletionPolicy": "Retain",
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/Table/Resource",
+      },
+      "Properties": Object {
+        "AttributeDefinitions": Array [
+          Object {
+            "AttributeName": "id",
+            "AttributeType": "S",
+          },
+        ],
+        "BillingMode": "PAY_PER_REQUEST",
+        "KeySchema": Array [
+          Object {
+            "AttributeName": "id",
+            "KeyType": "HASH",
+          },
+        ],
+      },
+      "Type": "AWS::DynamoDB::Table",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ThrottlerHandler750A7C89": Object {
+      "DependsOn": Array [
+        "ThrottlerHandlerServiceRoleA0481DAF",
+      ],
+      "Metadata": Object {
+        "aws:asset:is-bundled": false,
+        "aws:asset:path": "asset.03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640",
+        "aws:asset:property": "Code",
+        "aws:cdk:path": "CdkGeneralStackTest-US/ThrottlerHandler/Resource",
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
+          },
+          "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip",
+        },
+        "Handler": "hello.handler",
+        "ReservedConcurrentExecutions": 0,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "ThrottlerHandlerServiceRoleA0481DAF",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ThrottlerHandlerServiceRoleA0481DAF": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkGeneralStackTest-US/ThrottlerHandler/ServiceRole/Resource",
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+  "Transform": "SlicWatch-v3",
+}
+`
+
+exports[`cdk-test-project/tests/snapshot/cdk-test-project-snapshot.test.ts > TAP > cdk-test-project snapshot > stepFunctionStack fragment 1`] = `
+Object {
+  "Metadata": Object {
+    "slicWatch": Object {
+      "alarms": Object {
+        "Lambda": Object {
+          "Invocations": Object {
+            "enabled": true,
+            "Threshold": 10,
+          },
+        },
+        "SQS": Object {
+          "AgeOfOldestMessage": Object {
+            "enabled": true,
+            "Statistic": "Maximum",
+            "Threshold": 60,
+          },
+          "InFlightMessagesPc": Object {
+            "Statistic": "Maximum",
+            "Threshold": 1,
+          },
+        },
+      },
+      "enabled": true,
+      "topicArn": Object {
+        "Ref": "MyTopic86869434",
+      },
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "CDKMetadata": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkSFNStackTest-Europe/CDKMetadata/Default",
+      },
+      "Properties": Object {
+        "Analytics": "v2:deflate64:H4sIAAAAAAAA/11P0UoDQQz8lr7nolaQvtpCoaAgp+Djke6lbbp7u6XZq8iy/+7etoIIgZnJhEwyx8UT3s/oSxvT28bJFtN7JGOhtLqkXjF9hJMYWO18JRkcDdueMK1Hb6IEP1m/PIPQgKkNjqd2xbfgxHxP8soy6GNHqhwVnycoGpejsRyXpAwa+bS77dMuklrFl5q58Zdg/w1g+iSJsCZxsDoEMQzlgcivZA7i6xV/dc7QsobxXOZqeDH34vf12puRwYee8ah3l4cFlprPjirSnEcfZWBsr/gDsE52pTwBAAA=",
+      },
+      "Type": "AWS::CDK::Metadata",
+    },
+    "HelloHandler2E4FBA4D": Object {
+      "DependsOn": Array [
+        "HelloHandlerServiceRole11EF7C63",
+      ],
+      "Metadata": Object {
+        "slicWatch": Object {
+          "alarms": Object {
+            "Lambda": Object {
+              "Invocations": Object {
+                "Threshold": 4,
+              },
+            },
+          },
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
+          },
+          "S3Key": "03015a4df782c6ac9c6d09c548490f98a81c69c44e4262ca4c99d29652f52640.zip",
+        },
+        "Handler": "hello.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "HelloHandlerServiceRole11EF7C63",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "HelloHandlerServiceRole11EF7C63": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkSFNStackTest-Europe/HelloHandler/ServiceRole/Resource",
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "MyTopic86869434": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkSFNStackTest-Europe/MyTopic/Resource",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "slicWatchDashboard": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Sub": "{\\"start\\":\\"-PT3H\\",\\"widgets\\":[{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/States\\",\\"ExecutionsFailed\\",\\"StateMachineArn\\",\\"\${StateMachine2E01A3A5}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/States\\",\\"ExecutionThrottled\\",\\"StateMachineArn\\",\\"\${StateMachine2E01A3A5}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/States\\",\\"ExecutionsTimedOut\\",\\"StateMachineArn\\",\\"\${StateMachine2E01A3A5}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"\${StateMachine2E01A3A5.Name} Step Function Executions\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":0},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"Lambda Errors Sum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":0},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"Lambda Throttles Sum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":0},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"Average\\"}]],\\"title\\":\\"Lambda Duration Average per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":6},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"p95\\"}]],\\"title\\":\\"Lambda Duration p95 per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":6},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"Maximum\\"}]],\\"title\\":\\"Lambda Duration Maximum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":6},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"Lambda Invocations Sum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":12},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"\${HelloHandler2E4FBA4D}\\",{\\"stat\\":\\"Maximum\\"}]],\\"title\\":\\"Lambda ConcurrentExecutions Maximum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":12},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/SNS\\",\\"NumberOfNotificationsFilteredOut-InvalidAttributes\\",\\"TopicName\\",\\"\${MyTopic86869434.TopicName}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/SNS\\",\\"NumberOfNotificationsFailed\\",\\"TopicName\\",\\"\${MyTopic86869434.TopicName}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"SNS Topic \${MyTopic86869434.TopicName}\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":12}]}",
+        },
+        "DashboardName": Object {
+          "Fn::Sub": "\${AWS::StackName}-\${AWS::Region}-Dashboard",
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "slicWatchLambdaDurationAlarmHelloHandler2E4FBA4D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${HelloHandler2E4FBA4D} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${HelloHandler2E4FBA4D}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "HelloHandler2E4FBA4D",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmHelloHandler2E4FBA4D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${HelloHandler2E4FBA4D} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${HelloHandler2E4FBA4D}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "HelloHandler2E4FBA4D",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmHelloHandler2E4FBA4D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${HelloHandler2E4FBA4D} breaches 4",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${HelloHandler2E4FBA4D}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "HelloHandler2E4FBA4D",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 4,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmHelloHandler2E4FBA4D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${HelloHandler2E4FBA4D} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${HelloHandler2E4FBA4D}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "HelloHandler2E4FBA4D",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "HelloHandler2E4FBA4D",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchSNSNumberOfNotificationsFailedAlarmMyTopic86869434": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SNS NumberOfNotificationsFailed for \${MyTopic86869434.TopicName} breaches 1",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SNS_NumberOfNotificationsFailed_Alarm_\${MyTopic86869434.TopicName}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TopicName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "MyTopic86869434",
+                "TopicName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "NumberOfNotificationsFailed",
+        "Namespace": "AWS/SNS",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchSNSNumberOfNotificationsFilteredOutInvalidAttributesAlarmMyTopic86869434": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SNS NumberOfNotificationsFilteredOutInvalidAttributes for \${MyTopic86869434.TopicName} breaches 1",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SNS_NumberOfNotificationsFilteredOutInvalidAttributes_Alarm_\${MyTopic86869434.TopicName}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TopicName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "MyTopic86869434",
+                "TopicName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "NumberOfNotificationsFilteredOut-InvalidAttributes",
+        "Namespace": "AWS/SNS",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchStatesExecutionsFailedAlarmStateMachine2E01A3A5": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "StepFunctions ExecutionsFailed Sum for \${StateMachine2E01A3A5.Name}  breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "StepFunctions_ExecutionsFailedAlarm_\${StateMachine2E01A3A5.Name}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "StateMachineArn",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "StateMachine2E01A3A5",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ExecutionsFailed",
+        "Namespace": "AWS/States",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchStatesExecutionsTimedOutAlarmStateMachine2E01A3A5": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "StepFunctions ExecutionsTimedOut Sum for \${StateMachine2E01A3A5.Name}  breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "StepFunctions_ExecutionsTimedOutAlarm_\${StateMachine2E01A3A5.Name}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "StateMachineArn",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "StateMachine2E01A3A5",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ExecutionsTimedOut",
+        "Namespace": "AWS/States",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchStatesExecutionThrottledAlarmStateMachine2E01A3A5": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "StepFunctions ExecutionThrottled Sum for \${StateMachine2E01A3A5.Name}  breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "StepFunctions_ExecutionThrottledAlarm_\${StateMachine2E01A3A5.Name}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "StateMachineArn",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "StateMachine2E01A3A5",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ExecutionThrottled",
+        "Namespace": "AWS/States",
+        "OKActions": Array [],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "StateMachine2E01A3A5": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "StateMachineRoleDefaultPolicyDF1E6607",
+        "StateMachineRoleB840431D",
+      ],
+      "Metadata": Object {
+        "aws:cdk:path": "CdkSFNStackTest-Europe/StateMachine/Resource",
+      },
+      "Properties": Object {
+        "DefinitionString": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"StartAt\\":\\"Submit Job\\",\\"States\\":{\\"Submit Job\\":{\\"Next\\":\\"Wait X Seconds\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2}],\\"Type\\":\\"Task\\",\\"OutputPath\\":\\"$.Payload\\",\\"Resource\\":\\"arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke\\",\\"Parameters\\":{\\"FunctionName\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "HelloHandler2E4FBA4D",
+                  "Arn",
+                ],
+              },
+              "\\",\\"Payload.$\\":\\"$\\"}},\\"Wait X Seconds\\":{\\"Type\\":\\"Wait\\",\\"SecondsPath\\":\\"$.waitSeconds\\",\\"Next\\":\\"Get Job Status\\"},\\"Get Job Status\\":{\\"Next\\":\\"Job Complete?\\",\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2}],\\"Type\\":\\"Task\\",\\"InputPath\\":\\"$.guid\\",\\"OutputPath\\":\\"$.Payload\\",\\"Resource\\":\\"arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke\\",\\"Parameters\\":{\\"FunctionName\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "HelloHandler2E4FBA4D",
+                  "Arn",
+                ],
+              },
+              "\\",\\"Payload.$\\":\\"$\\"}},\\"Job Complete?\\":{\\"Type\\":\\"Choice\\",\\"Choices\\":[{\\"Variable\\":\\"$.status\\",\\"StringEquals\\":\\"FAILED\\",\\"Next\\":\\"Job Failed\\"},{\\"Variable\\":\\"$.status\\",\\"StringEquals\\":\\"SUCCEEDED\\",\\"Next\\":\\"Get Final Job Status\\"}],\\"Default\\":\\"Wait X Seconds\\"},\\"Job Failed\\":{\\"Type\\":\\"Fail\\",\\"Error\\":\\"DescribeJob returned FAILED\\",\\"Cause\\":\\"AWS Batch Job Failed\\"},\\"Get Final Job Status\\":{\\"End\\":true,\\"Retry\\":[{\\"ErrorEquals\\":[\\"Lambda.ServiceException\\",\\"Lambda.AWSLambdaException\\",\\"Lambda.SdkClientException\\"],\\"IntervalSeconds\\":2,\\"MaxAttempts\\":6,\\"BackoffRate\\":2}],\\"Type\\":\\"Task\\",\\"InputPath\\":\\"$.guid\\",\\"OutputPath\\":\\"$.Payload\\",\\"Resource\\":\\"arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke\\",\\"Parameters\\":{\\"FunctionName\\":\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "HelloHandler2E4FBA4D",
+                  "Arn",
+                ],
+              },
+              "\\",\\"Payload.$\\":\\"$\\"}}},\\"TimeoutSeconds\\":300}",
+            ],
+          ],
+        },
+        "RoleArn": Object {
+          "Fn::GetAtt": Array [
+            "StateMachineRoleB840431D",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::StepFunctions::StateMachine",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "StateMachineRoleB840431D": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkSFNStackTest-Europe/StateMachine/Role/Resource",
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "states.eu-west-1.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "StateMachineRoleDefaultPolicyDF1E6607": Object {
+      "Metadata": Object {
+        "aws:cdk:path": "CdkSFNStackTest-Europe/StateMachine/Role/DefaultPolicy/Resource",
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "HelloHandler2E4FBA4D",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "HelloHandler2E4FBA4D",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "StateMachineRoleDefaultPolicyDF1E6607",
+        "Roles": Array [
+          Object {
+            "Ref": "StateMachineRoleB840431D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+  "Transform": "SlicWatch-v3",
+}
+`

--- a/tap-snapshots/sam-test-project/tests/snapshot/sam-test-project-snapshot.test.ts.test.cjs
+++ b/tap-snapshots/sam-test-project/tests/snapshot/sam-test-project-snapshot.test.ts.test.cjs
@@ -1,0 +1,4140 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`sam-test-project/tests/snapshot/sam-test-project-snapshot.test.ts > TAP > sam-test-project snapshot > fragment 1`] = `
+Object {
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "sam-test-project",
+  "Metadata": Object {
+    "slicWatch": Object {
+      "alarmActionsConfig": Object {
+        "actionsEnabled": true,
+        "alarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "okActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+      },
+      "alarms": Object {
+        "Lambda": Object {
+          "Invocations": Object {
+            "enabled": true,
+            "Threshold": 10,
+          },
+        },
+        "SQS": Object {
+          "AgeOfOldestMessage": Object {
+            "enabled": true,
+            "Statistic": "Maximum",
+            "Threshold": 60,
+          },
+          "InFlightMessagesPc": Object {
+            "Statistic": "Maximum",
+            "Threshold": 1,
+          },
+        },
+      },
+      "enabled": true,
+    },
+  },
+  "Resources": Object {
+    "dataTable": Object {
+      "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "SamResourceId": "dataTable",
+      },
+      "Properties": Object {
+        "AttributeDefinitions": Array [
+          Object {
+            "AttributeName": "pk",
+            "AttributeType": "S",
+          },
+          Object {
+            "AttributeName": "sk",
+            "AttributeType": "S",
+          },
+          Object {
+            "AttributeName": "gsi1pk",
+            "AttributeType": "S",
+          },
+          Object {
+            "AttributeName": "gsi1sk",
+            "AttributeType": "S",
+          },
+          Object {
+            "AttributeName": "timestamp",
+            "AttributeType": "N",
+          },
+        ],
+        "GlobalSecondaryIndexes": Array [
+          Object {
+            "IndexName": "GSI1",
+            "KeySchema": Array [
+              Object {
+                "AttributeName": "gsi1pk",
+                "KeyType": "HASH",
+              },
+              Object {
+                "AttributeName": "gsi1sk",
+                "KeyType": "RANGE",
+              },
+            ],
+            "Projection": Object {
+              "NonKeyAttributes": Array [
+                "address",
+              ],
+              "ProjectionType": "INCLUDE",
+            },
+            "ProvisionedThroughput": Object {
+              "ReadCapacityUnits": 1,
+              "WriteCapacityUnits": 1,
+            },
+          },
+        ],
+        "KeySchema": Array [
+          Object {
+            "AttributeName": "pk",
+            "KeyType": "HASH",
+          },
+          Object {
+            "AttributeName": "sk",
+            "KeyType": "RANGE",
+          },
+        ],
+        "LocalSecondaryIndexes": Array [
+          Object {
+            "IndexName": "LSI1",
+            "KeySchema": Array [
+              Object {
+                "AttributeName": "pk",
+                "KeyType": "HASH",
+              },
+              Object {
+                "AttributeName": "timestamp",
+                "KeyType": "RANGE",
+              },
+            ],
+            "Projection": Object {
+              "NonKeyAttributes": Array [
+                "name",
+              ],
+              "ProjectionType": "INCLUDE",
+            },
+          },
+        ],
+        "ProvisionedThroughput": Object {
+          "ReadCapacityUnits": 1,
+          "WriteCapacityUnits": 1,
+        },
+      },
+      "Type": "AWS::DynamoDB::Table",
+    },
+    "driveQueue": Object {
+      "Metadata": Object {
+        "SamResourceId": "driveQueue",
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "S3Key": "sam-test-project/841a60f2d379216bd90fa34e033d0596",
+        },
+        "Handler": "basic-handler.hello",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "driveQueueRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": Array [
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+        ],
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "driveQueueRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "driveStream": Object {
+      "Metadata": Object {
+        "SamResourceId": "driveStream",
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "S3Key": "sam-test-project/841a60f2d379216bd90fa34e033d0596",
+        },
+        "Handler": "stream-test-handler.handleDrive",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "driveStreamRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": Array [
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+        ],
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "driveStreamRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "driveTable": Object {
+      "Metadata": Object {
+        "SamResourceId": "driveTable",
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "S3Key": "sam-test-project/841a60f2d379216bd90fa34e033d0596",
+        },
+        "Handler": "basic-handler.hello",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "driveTableRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": Array [
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+        ],
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "driveTableRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ecsCluster": Object {
+      "Metadata": Object {
+        "SamResourceId": "ecsCluster",
+      },
+      "Type": "AWS::ECS::Cluster",
+    },
+    "ecsService": Object {
+      "Metadata": Object {
+        "SamResourceId": "ecsService",
+      },
+      "Properties": Object {
+        "Cluster": Object {
+          "Ref": "ecsCluster",
+        },
+        "DesiredCount": 0,
+        "LaunchType": "FARGATE",
+        "NetworkConfiguration": Object {
+          "AwsvpcConfiguration": Object {
+            "AssignPublicIp": "ENABLED",
+            "SecurityGroups": Array [],
+            "Subnets": Array [
+              Object {
+                "Ref": "subnet",
+              },
+            ],
+          },
+        },
+        "TaskDefinition": Object {
+          "Ref": "taskDef",
+        },
+      },
+      "Type": "AWS::ECS::Service",
+    },
+    "eventsRule": Object {
+      "Metadata": Object {
+        "SamResourceId": "eventsRule",
+        "slicWatch": Object {
+          "alarms": Object {
+            "Lambda": Object {
+              "enabled": false,
+            },
+          },
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "S3Key": "sam-test-project/841a60f2d379216bd90fa34e033d0596",
+        },
+        "Handler": "rule-handler.handleRule",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "eventsRuleRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": Array [
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+        ],
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "eventsRuleRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "eventsRuleTrigger": Object {
+      "Properties": Object {
+        "EventPattern": Object {
+          "detail-type": Array [
+            "Invoke Lambda Function",
+          ],
+        },
+        "Targets": Array [
+          Object {
+            "Arn": Object {
+              "Fn::GetAtt": Array [
+                "eventsRule",
+                "Arn",
+              ],
+            },
+            "Id": "eventsRuleTriggerLambdaTarget",
+            "RetryPolicy": Object {
+              "MaximumEventAgeInSeconds": 60,
+              "MaximumRetryAttempts": 0,
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "eventsRuleTriggerPermission": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Ref": "eventsRule",
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::GetAtt": Array [
+            "eventsRuleTrigger",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "fifoQueue": Object {
+      "Metadata": Object {
+        "SamResourceId": "fifoQueue",
+      },
+      "Properties": Object {
+        "FifoQueue": true,
+      },
+      "Type": "AWS::SQS::Queue",
+    },
+    "hello": Object {
+      "Metadata": Object {
+        "SamResourceId": "hello",
+        "slicWatch": Object {
+          "alarms": Object {
+            "Lambda": Object {
+              "Invocations": Object {
+                "Threshold": 2,
+              },
+            },
+          },
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "S3Key": "sam-test-project/841a60f2d379216bd90fa34e033d0596",
+        },
+        "Handler": "basic-handler.hello",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "helloRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": Array [
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+        ],
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "helloRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "httpGetter": Object {
+      "Metadata": Object {
+        "SamResourceId": "httpGetter",
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "S3Key": "sam-test-project/841a60f2d379216bd90fa34e033d0596",
+        },
+        "Handler": "apigw-handler.handleGet",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "httpGetterRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": Array [
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "httpGetterHttpApiEventPermission": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Ref": "httpGetter",
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": Object {
+          "Fn::Sub": Array [
+            "arn:\${AWS::Partition}:execute-api:\${AWS::Region}:\${AWS::AccountId}:\${__ApiId__}/\${__Stage__}/GETitem",
+            Object {
+              "__ApiId__": Object {
+                "Ref": "ServerlessHttpApi",
+              },
+              "__Stage__": "*",
+            },
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "httpGetterRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "MonitoringTopic": Object {
+      "Metadata": Object {
+        "SamResourceId": "MonitoringTopic",
+      },
+      "Properties": Object {
+        "TopicName": "SS-Alarm-Topic3",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "ping": Object {
+      "Metadata": Object {
+        "SamResourceId": "ping",
+        "slicWatch": Object {
+          "dashboard": Object {
+            "enabled": false,
+          },
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "S3Key": "sam-test-project/841a60f2d379216bd90fa34e033d0596",
+        },
+        "Handler": "basic-handler.hello",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "pingRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": Array [
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+        ],
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "pingRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "regularQueue": Object {
+      "Metadata": Object {
+        "SamResourceId": "regularQueue",
+      },
+      "Type": "AWS::SQS::Queue",
+    },
+    "ServerlessHttpApi": Object {
+      "Properties": Object {
+        "Body": Object {
+          "info": Object {
+            "title": Object {
+              "Ref": "AWS::StackName",
+            },
+            "version": "1.0",
+          },
+          "openapi": "3.0.1",
+          "paths": Object {
+            "item": Object {
+              "get": Object {
+                "responses": Object {},
+                "x-amazon-apigateway-integration": Object {
+                  "httpMethod": "POST",
+                  "payloadFormatVersion": "2.0",
+                  "type": "aws_proxy",
+                  "uri": Object {
+                    "Fn::Sub": "arn:\${AWS::Partition}:apigateway:\${AWS::Region}:lambda:path/2015-03-31/functions/\${httpGetter.Arn}/invocations",
+                  },
+                },
+              },
+            },
+          },
+          "tags": Array [
+            Object {
+              "name": "httpapi:createdBy",
+              "x-amazon-apigateway-tag-value": "SAM",
+            },
+          ],
+        },
+      },
+      "Type": "AWS::ApiGatewayV2::Api",
+    },
+    "ServerlessHttpApiApiGatewayDefaultStage": Object {
+      "Properties": Object {
+        "ApiId": Object {
+          "Ref": "ServerlessHttpApi",
+        },
+        "AutoDeploy": true,
+        "StageName": "$default",
+        "Tags": Object {
+          "httpapi:createdBy": "SAM",
+        },
+      },
+      "Type": "AWS::ApiGatewayV2::Stage",
+    },
+    "slicWatchDashboard": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Sub": "{\\"start\\":\\"-PT3H\\",\\"widgets\\":[{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/States\\",\\"ExecutionsFailed\\",\\"StateMachineArn\\",\\"\${TestStateMachine}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/States\\",\\"ExecutionThrottled\\",\\"StateMachineArn\\",\\"\${TestStateMachine}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/States\\",\\"ExecutionsTimedOut\\",\\"StateMachineArn\\",\\"\${TestStateMachine}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"\${TestStateMachine.Name} Step Function Executions\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":0},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/DynamoDB\\",\\"ReadThrottleEvents\\",\\"TableName\\",\\"\${dataTable}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"ReadThrottleEvents Table \${dataTable}\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":0},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/DynamoDB\\",\\"ReadThrottleEvents\\",\\"TableName\\",\\"\${dataTable}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/DynamoDB\\",\\"ReadThrottleEvents\\",\\"TableName\\",\\"\${dataTable}\\",\\"GlobalSecondaryIndex\\",\\"GSI1\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"ReadThrottleEvents GSI GSI1 in \${dataTable}\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":0},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/DynamoDB\\",\\"ReadThrottleEvents\\",\\"TableName\\",\\"\${dataTable}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/DynamoDB\\",\\"ReadThrottleEvents\\",\\"TableName\\",\\"\${dataTable}\\",\\"GlobalSecondaryIndex\\",\\"GSI1\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/DynamoDB\\",\\"WriteThrottleEvents\\",\\"TableName\\",\\"\${dataTable}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"WriteThrottleEvents Table \${dataTable}\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":6},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/DynamoDB\\",\\"ReadThrottleEvents\\",\\"TableName\\",\\"\${dataTable}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/DynamoDB\\",\\"ReadThrottleEvents\\",\\"TableName\\",\\"\${dataTable}\\",\\"GlobalSecondaryIndex\\",\\"GSI1\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/DynamoDB\\",\\"WriteThrottleEvents\\",\\"TableName\\",\\"\${dataTable}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/DynamoDB\\",\\"WriteThrottleEvents\\",\\"TableName\\",\\"\${dataTable}\\",\\"GlobalSecondaryIndex\\",\\"GSI1\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"WriteThrottleEvents GSI GSI1 in \${dataTable}\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":6},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"\${hello}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"\${throttler}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"\${driveStream}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"\${driveQueue}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"\${driveTable}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"\${streamProcessor}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"\${httpGetter}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"\${eventsRule}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"Lambda Errors Sum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":6},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"\${hello}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"\${throttler}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"\${driveStream}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"\${driveQueue}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"\${driveTable}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"\${streamProcessor}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"\${httpGetter}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"\${eventsRule}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"Lambda Throttles Sum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":12},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${hello}\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${throttler}\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${driveStream}\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${driveQueue}\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${driveTable}\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${streamProcessor}\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${httpGetter}\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${eventsRule}\\",{\\"stat\\":\\"Average\\"}]],\\"title\\":\\"Lambda Duration Average per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":12},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${hello}\\",{\\"stat\\":\\"p95\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${throttler}\\",{\\"stat\\":\\"p95\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${driveStream}\\",{\\"stat\\":\\"p95\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${driveQueue}\\",{\\"stat\\":\\"p95\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${driveTable}\\",{\\"stat\\":\\"p95\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${streamProcessor}\\",{\\"stat\\":\\"p95\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${httpGetter}\\",{\\"stat\\":\\"p95\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${eventsRule}\\",{\\"stat\\":\\"p95\\"}]],\\"title\\":\\"Lambda Duration p95 per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":12},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${hello}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${throttler}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${driveStream}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${driveQueue}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${driveTable}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${streamProcessor}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${httpGetter}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"\${eventsRule}\\",{\\"stat\\":\\"Maximum\\"}]],\\"title\\":\\"Lambda Duration Maximum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":18},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"\${hello}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"\${throttler}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"\${driveStream}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"\${driveQueue}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"\${driveTable}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"\${streamProcessor}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"\${httpGetter}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"\${eventsRule}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"Lambda Invocations Sum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":18},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"\${hello}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"\${throttler}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"\${driveStream}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"\${driveQueue}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"\${driveTable}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"\${streamProcessor}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"\${httpGetter}\\",{\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"\${eventsRule}\\",{\\"stat\\":\\"Maximum\\"}]],\\"title\\":\\"Lambda ConcurrentExecutions Maximum per Function\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":18},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Lambda\\",\\"IteratorAge\\",\\"FunctionName\\",\\"\${streamProcessor}\\",{\\"stat\\":\\"Maximum\\"}]],\\"title\\":\\"Lambda IteratorAge \${streamProcessor} Maximum\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":24},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Kinesis\\",\\"GetRecords.IteratorAgeMilliseconds\\",\\"StreamName\\",\\"\${stream}\\",{\\"stat\\":\\"Maximum\\"}]],\\"title\\":\\"IteratorAge \${stream} Kinesis\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":24},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Kinesis\\",\\"PutRecord.Success\\",\\"StreamName\\",\\"\${stream}\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/Kinesis\\",\\"PutRecords.Success\\",\\"StreamName\\",\\"\${stream}\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/Kinesis\\",\\"GetRecords.Success\\",\\"StreamName\\",\\"\${stream}\\",{\\"stat\\":\\"Average\\"}]],\\"title\\":\\"Get/Put Success \${stream} Kinesis\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":24},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Kinesis\\",\\"ReadProvisionedThroughputExceeded\\",\\"StreamName\\",\\"\${stream}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Kinesis\\",\\"WriteProvisionedThroughputExceeded\\",\\"StreamName\\",\\"\${stream}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"Provisioned Throughput \${stream} Kinesis\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":30},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/SQS\\",\\"NumberOfMessagesSent\\",\\"QueueName\\",\\"\${regularQueue.QueueName}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/SQS\\",\\"NumberOfMessagesReceived\\",\\"QueueName\\",\\"\${regularQueue.QueueName}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/SQS\\",\\"NumberOfMessagesDeleted\\",\\"QueueName\\",\\"\${regularQueue.QueueName}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"Messages \${regularQueue.QueueName} SQS\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":30},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/SQS\\",\\"ApproximateAgeOfOldestMessage\\",\\"QueueName\\",\\"\${regularQueue.QueueName}\\",{\\"stat\\":\\"Maximum\\"}]],\\"title\\":\\"Oldest Message age \${regularQueue.QueueName} SQS\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":30},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/SQS\\",\\"ApproximateNumberOfMessagesVisible\\",\\"QueueName\\",\\"\${regularQueue.QueueName}\\",{\\"stat\\":\\"Maximum\\"}]],\\"title\\":\\"Messages in queue \${regularQueue.QueueName} SQS\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":36},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/SQS\\",\\"NumberOfMessagesSent\\",\\"QueueName\\",\\"\${fifoQueue.QueueName}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/SQS\\",\\"NumberOfMessagesReceived\\",\\"QueueName\\",\\"\${fifoQueue.QueueName}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/SQS\\",\\"NumberOfMessagesDeleted\\",\\"QueueName\\",\\"\${fifoQueue.QueueName}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"Messages \${fifoQueue.QueueName} SQS\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":36},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/SQS\\",\\"ApproximateAgeOfOldestMessage\\",\\"QueueName\\",\\"\${fifoQueue.QueueName}\\",{\\"stat\\":\\"Maximum\\"}]],\\"title\\":\\"Oldest Message age \${fifoQueue.QueueName} SQS\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":36},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/SQS\\",\\"ApproximateNumberOfMessagesVisible\\",\\"QueueName\\",\\"\${fifoQueue.QueueName}\\",{\\"stat\\":\\"Maximum\\"}]],\\"title\\":\\"Messages in queue \${fifoQueue.QueueName} SQS\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":42},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/ECS\\",\\"MemoryUtilization\\",\\"ServiceName\\",\\"\${ecsService.Name}\\",\\"ClusterName\\",\\"\${ecsCluster}\\",{\\"stat\\":\\"Average\\"}],[\\"AWS/ECS\\",\\"CPUUtilization\\",\\"ServiceName\\",\\"\${ecsService.Name}\\",\\"ClusterName\\",\\"\${ecsCluster}\\",{\\"stat\\":\\"Average\\"}]],\\"title\\":\\"ECS Service \${ecsService.Name}\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":42},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/SNS\\",\\"NumberOfNotificationsFilteredOut-InvalidAttributes\\",\\"TopicName\\",\\"\${MonitoringTopic.TopicName}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/SNS\\",\\"NumberOfNotificationsFailed\\",\\"TopicName\\",\\"\${MonitoringTopic.TopicName}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"SNS Topic \${MonitoringTopic.TopicName}\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":42},{\\"type\\":\\"metric\\",\\"properties\\":{\\"metrics\\":[[\\"AWS/Events\\",\\"FailedInvocations\\",\\"RuleName\\",\\"\${eventsRuleTrigger}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Events\\",\\"ThrottledRules\\",\\"RuleName\\",\\"\${eventsRuleTrigger}\\",{\\"stat\\":\\"Sum\\"}],[\\"AWS/Events\\",\\"Invocations\\",\\"RuleName\\",\\"\${eventsRuleTrigger}\\",{\\"stat\\":\\"Sum\\"}]],\\"title\\":\\"EventBridge Rule \${eventsRuleTrigger}\\",\\"view\\":\\"timeSeries\\",\\"region\\":\\"\${AWS::Region}\\",\\"period\\":300},\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":48}]}",
+        },
+        "DashboardName": Object {
+          "Fn::Sub": "\${AWS::StackName}-\${AWS::Region}-Dashboard",
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "slicWatchECSCPUAlarmecsService": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "ECS CPUUtilization for \${ecsService.Name} breaches 90",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "ECS_CPUAlarm_\${ecsService.Name}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "ServiceName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "ecsService",
+                "Name",
+              ],
+            },
+          },
+          Object {
+            "Name": "ClusterName",
+            "Value": Object {
+              "Ref": "ecsCluster",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "CPUUtilization",
+        "Namespace": "AWS/ECS",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 90,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchECSMemoryAlarmecsService": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "ECS MemoryUtilization for \${ecsService.Name} breaches 90",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "ECS_MemoryAlarm_\${ecsService.Name}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "ServiceName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "ecsService",
+                "Name",
+              ],
+            },
+          },
+          Object {
+            "Name": "ClusterName",
+            "Value": Object {
+              "Ref": "ecsCluster",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "MemoryUtilization",
+        "Namespace": "AWS/ECS",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 90,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchEventsFailedInvocationsAlarmEventsRuleTrigger": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "EventBridge FailedInvocations for \${eventsRuleTrigger} breaches 1",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Events_FailedInvocations_Alarm_\${eventsRuleTrigger}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "RuleName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "eventsRuleTrigger",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "FailedInvocations",
+        "Namespace": "AWS/Events",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchEventsThrottledRulesAlarmEventsRuleTrigger": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "EventBridge ThrottledRules for \${eventsRuleTrigger} breaches 1",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Events_ThrottledRules_Alarm_\${eventsRuleTrigger}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "RuleName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "eventsRuleTrigger",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ThrottledRules",
+        "Namespace": "AWS/Events",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchGSIReadThrottleEventsAlarmdataTableGSI1": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DynamoDB Sum for \${dataTable}GSI1 breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DDB_ReadThrottleEvents_Alarm_\${dataTable}GSI1",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TableName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "dataTable",
+            },
+          },
+          Object {
+            "Name": "GlobalSecondaryIndex",
+            "Value": "GSI1",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ReadThrottleEvents",
+        "Namespace": "AWS/DynamoDB",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchGSIWriteThrottleEventsAlarmdataTableGSI1": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DynamoDB Sum for \${dataTable}GSI1 breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DDB_WriteThrottleEvents_Alarm_\${dataTable}GSI1",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TableName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "dataTable",
+            },
+          },
+          Object {
+            "Name": "GlobalSecondaryIndex",
+            "Value": "GSI1",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "WriteThrottleEvents",
+        "Namespace": "AWS/DynamoDB",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchKinesisStreamGetRecordsSuccessAlarmStream": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Kinesis Average GetRecords.Success for \${stream} breaches 1 milliseconds",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Kinesis_StreamGetRecordsSuccess_\${stream}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "StreamName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "stream",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "GetRecords.Success",
+        "Namespace": "AWS/Kinesis",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchKinesisStreamIteratorAgeAlarmStream": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Kinesis Maximum GetRecords.IteratorAgeMilliseconds for \${stream} breaches 10000 milliseconds",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Kinesis_StreamIteratorAge_\${stream}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "StreamName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "stream",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "GetRecords.IteratorAgeMilliseconds",
+        "Namespace": "AWS/Kinesis",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 10000,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchKinesisStreamPutRecordsSuccessAlarmStream": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Kinesis Average PutRecords.Success for \${stream} breaches 1 milliseconds",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Kinesis_StreamPutRecordsSuccess_\${stream}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "StreamName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "stream",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "PutRecords.Success",
+        "Namespace": "AWS/Kinesis",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchKinesisStreamPutRecordSuccessAlarmStream": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Kinesis Average PutRecord.Success for \${stream} breaches 1 milliseconds",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Kinesis_StreamPutRecordSuccess_\${stream}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "StreamName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "stream",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "PutRecord.Success",
+        "Namespace": "AWS/Kinesis",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchKinesisStreamReadThroughputAlarmStream": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Kinesis Sum ReadProvisionedThroughputExceeded for \${stream} breaches 0 milliseconds",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Kinesis_StreamReadThroughput_\${stream}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "StreamName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "stream",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ReadProvisionedThroughputExceeded",
+        "Namespace": "AWS/Kinesis",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchKinesisStreamWriteThroughputAlarmStream": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Kinesis Sum WriteProvisionedThroughputExceeded for \${stream} breaches 0 milliseconds",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Kinesis_StreamWriteThroughput_\${stream}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "StreamName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "stream",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "WriteProvisionedThroughputExceeded",
+        "Namespace": "AWS/Kinesis",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmdriveQueue": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${driveQueue} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${driveQueue}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "driveQueue",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmdriveStream": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${driveStream} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${driveStream}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "driveStream",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmdriveTable": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${driveTable} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${driveTable}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "driveTable",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmhello": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${hello} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${hello}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "hello",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmhttpGetter": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${httpGetter} breaches 95% of timeout (30)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${httpGetter}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "httpGetter",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 28500,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmping": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${ping} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${ping}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "ping",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmstreamProcessor": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${streamProcessor} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${streamProcessor}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "streamProcessor",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaDurationAlarmthrottler": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Max duration for \${throttler} breaches 95% of timeout (3)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Duration_\${throttler}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "throttler",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Duration",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 2850,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmdriveQueue": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${driveQueue} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${driveQueue}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "driveQueue",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmdriveStream": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${driveStream} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${driveStream}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "driveStream",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmdriveTable": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${driveTable} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${driveTable}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "driveTable",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmhello": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${hello} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${hello}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "hello",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmhttpGetter": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${httpGetter} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${httpGetter}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "httpGetter",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmping": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${ping} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${ping}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "ping",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmstreamProcessor": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${streamProcessor} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${streamProcessor}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "streamProcessor",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaErrorsAlarmthrottler": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Error count for \${throttler} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Errors_\${throttler}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "throttler",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Errors",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmdriveQueue": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${driveQueue} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${driveQueue}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "driveQueue",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmdriveStream": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${driveStream} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${driveStream}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "driveStream",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmdriveTable": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${driveTable} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${driveTable}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "driveTable",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmhello": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${hello} breaches 2",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${hello}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "hello",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 2,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmhttpGetter": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${httpGetter} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${httpGetter}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "httpGetter",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmping": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${ping} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${ping}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "ping",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmstreamProcessor": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${streamProcessor} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${streamProcessor}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "streamProcessor",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaInvocationsAlarmthrottler": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Total invocations for \${throttler} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Invocations_\${throttler}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "throttler",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaIteratorAgeAlarmstreamProcessor": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "IteratorAge for \${streamProcessor} breaches 10000",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_IteratorAge_\${streamProcessor}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "FunctionName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "streamProcessor",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "IteratorAge",
+        "Metrics": undefined,
+        "Namespace": "AWS/Lambda",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 10000,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmdriveQueue": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${driveQueue} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${driveQueue}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "driveQueue",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "driveQueue",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmdriveStream": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${driveStream} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${driveStream}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "driveStream",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "driveStream",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmdriveTable": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${driveTable} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${driveTable}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "driveTable",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "driveTable",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmhello": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${hello} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${hello}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "hello",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "hello",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmhttpGetter": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${httpGetter} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${httpGetter}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "httpGetter",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "httpGetter",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmping": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${ping} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${ping}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "ping",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "ping",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmstreamProcessor": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${streamProcessor} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${streamProcessor}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "streamProcessor",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "streamProcessor",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchLambdaThrottlesAlarmthrottler": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Throttles % for \${throttler} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "Lambda_Throttles_\${throttler}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "(throttles / ( throttles + invocations )) * 100",
+            "Id": "throttles_pc",
+            "Label": "% Throttles",
+            "ReturnData": true,
+          },
+          Object {
+            "Id": "throttles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "throttler",
+                    },
+                  },
+                ],
+                "MetricName": "Throttles",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          Object {
+            "Id": "invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": IntrinsicFunction {
+                      "name": "Ref",
+                      "payload": "throttler",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchSNSNumberOfNotificationsFailedAlarmMonitoringTopic": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SNS NumberOfNotificationsFailed for \${MonitoringTopic.TopicName} breaches 1",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SNS_NumberOfNotificationsFailed_Alarm_\${MonitoringTopic.TopicName}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TopicName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "MonitoringTopic",
+                "TopicName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "NumberOfNotificationsFailed",
+        "Namespace": "AWS/SNS",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchSNSNumberOfNotificationsFilteredOutInvalidAttributesAlarmMonitoringTopic": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SNS NumberOfNotificationsFilteredOutInvalidAttributes for \${MonitoringTopic.TopicName} breaches 1",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SNS_NumberOfNotificationsFilteredOutInvalidAttributes_Alarm_\${MonitoringTopic.TopicName}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TopicName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "MonitoringTopic",
+                "TopicName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "NumberOfNotificationsFilteredOut-InvalidAttributes",
+        "Namespace": "AWS/SNS",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchSQSInFlightMsgsAlarmfifoQueue": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SQS in-flight messages for \${fifoQueue.QueueName} breaches 200 (1% of the hard limit of 20000)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SQS_ApproximateNumberOfMessagesNotVisible_\${fifoQueue.QueueName}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "fifoQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesNotVisible",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 200,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchSQSInFlightMsgsAlarmregularQueue": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SQS in-flight messages for \${regularQueue.QueueName} breaches 1200 (1% of the hard limit of 120000)",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SQS_ApproximateNumberOfMessagesNotVisible_\${regularQueue.QueueName}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "regularQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesNotVisible",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 1200,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchSQSOldestMsgAgeAlarmfifoQueue": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SQS age of oldest message in the queue \${fifoQueue.QueueName} breaches 60",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SQS_ApproximateAgeOfOldestMessage_\${fifoQueue.QueueName}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "fifoQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateAgeOfOldestMessage",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 60,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchSQSOldestMsgAgeAlarmregularQueue": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SQS age of oldest message in the queue \${regularQueue.QueueName} breaches 60",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "SQS_ApproximateAgeOfOldestMessage_\${regularQueue.QueueName}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": IntrinsicFunction {
+              "name": "Fn::GetAtt",
+              "payload": Array [
+                "regularQueue",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateAgeOfOldestMessage",
+        "Namespace": "AWS/SQS",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 60,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchStatesExecutionsFailedAlarmTestStateMachine": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "StepFunctions ExecutionsFailed Sum for \${TestStateMachine.Name}  breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "StepFunctions_ExecutionsFailedAlarm_\${TestStateMachine.Name}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "StateMachineArn",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "TestStateMachine",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ExecutionsFailed",
+        "Namespace": "AWS/States",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchStatesExecutionsTimedOutAlarmTestStateMachine": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "StepFunctions ExecutionsTimedOut Sum for \${TestStateMachine.Name}  breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "StepFunctions_ExecutionsTimedOutAlarm_\${TestStateMachine.Name}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "StateMachineArn",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "TestStateMachine",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ExecutionsTimedOut",
+        "Namespace": "AWS/States",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchStatesExecutionThrottledAlarmTestStateMachine": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "StepFunctions ExecutionThrottled Sum for \${TestStateMachine.Name}  breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "StepFunctions_ExecutionThrottledAlarm_\${TestStateMachine.Name}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "StateMachineArn",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "TestStateMachine",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ExecutionThrottled",
+        "Namespace": "AWS/States",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchTableReadThrottleEventsAlarmdataTable": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DynamoDB Sum for \${dataTable} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DDB_ReadThrottleEvents_Alarm_\${dataTable}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TableName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "dataTable",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ReadThrottleEvents",
+        "Namespace": "AWS/DynamoDB",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchTableSystemErrorsAlarmdataTable": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DynamoDB Sum for \${dataTable} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DDB_SystemErrors_Alarm_\${dataTable}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TableName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "dataTable",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "SystemErrors",
+        "Namespace": "AWS/DynamoDB",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchTableUserErrorsAlarmdataTable": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DynamoDB Sum for \${dataTable} breaches 0",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DDB_UserErrors_Alarm_\${dataTable}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TableName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "dataTable",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "UserErrors",
+        "Namespace": "AWS/DynamoDB",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "slicWatchTableWriteThrottleEventsAlarmdataTable": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "AlarmDescription": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DynamoDB Sum for \${dataTable} breaches 10",
+            Object {},
+          ],
+        },
+        "AlarmName": IntrinsicFunction {
+          "name": "Fn::Sub",
+          "payload": Array [
+            "DDB_WriteThrottleEvents_Alarm_\${dataTable}",
+            Object {},
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "TableName",
+            "Value": IntrinsicFunction {
+              "name": "Ref",
+              "payload": "dataTable",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "WriteThrottleEvents",
+        "Namespace": "AWS/DynamoDB",
+        "OKActions": Array [
+          Object {
+            "Ref": "MonitoringTopic",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "stream": Object {
+      "Metadata": Object {
+        "SamResourceId": "stream",
+      },
+      "Properties": Object {
+        "ShardCount": 1,
+      },
+      "Type": "AWS::Kinesis::Stream",
+    },
+    "streamProcessor": Object {
+      "Metadata": Object {
+        "SamResourceId": "streamProcessor",
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "S3Key": "sam-test-project/841a60f2d379216bd90fa34e033d0596",
+        },
+        "Handler": "basic-handler.hello",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "streamProcessorRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": Array [
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+        ],
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "streamProcessorRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole",
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "streamProcessorStream": Object {
+      "Properties": Object {
+        "EventSourceArn": Object {
+          "Fn::GetAtt": Array [
+            "stream",
+            "Arn",
+          ],
+        },
+        "FunctionName": Object {
+          "Ref": "streamProcessor",
+        },
+        "MaximumRetryAttempts": 0,
+        "StartingPosition": "LATEST",
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
+    },
+    "subnet": Object {
+      "Metadata": Object {
+        "SamResourceId": "subnet",
+      },
+      "Properties": Object {
+        "AvailabilityZone": Object {
+          "Fn::Select": Array [
+            0,
+            Object {
+              "Fn::GetAZs": Object {
+                "Ref": "AWS::Region",
+              },
+            },
+          ],
+        },
+        "CidrBlock": "10.0.16.0/20",
+        "VpcId": Object {
+          "Ref": "vpc",
+        },
+      },
+      "Type": "AWS::EC2::Subnet",
+    },
+    "taskDef": Object {
+      "Metadata": Object {
+        "SamResourceId": "taskDef",
+      },
+      "Properties": Object {
+        "ContainerDefinitions": Array [
+          Object {
+            "Command": Array [
+              "/bin/sh -c \\"while true; do echo Hello; sleep 10; done\\"",
+            ],
+            "Cpu": 256,
+            "EntryPoint": Array [
+              "sh",
+              "-c",
+            ],
+            "Essential": true,
+            "Image": "busybox",
+            "Memory": 512,
+            "Name": "busybox",
+          },
+        ],
+        "Cpu": 256,
+        "Memory": 512,
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": Array [
+          "FARGATE",
+        ],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "TestStateMachine": Object {
+      "Metadata": Object {
+        "SamResourceId": "TestStateMachine",
+      },
+      "Properties": Object {
+        "DefinitionS3Location": Object {
+          "Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "Key": "sam-test-project/754f906d12f592f99c5651c04a6a0a51",
+        },
+        "DefinitionSubstitutions": Object {
+          "AnotherHelloArn": Object {
+            "Fn::GetAtt": Array [
+              "hello",
+              "Arn",
+            ],
+          },
+          "HelloArn": Object {
+            "Fn::GetAtt": Array [
+              "hello",
+              "Arn",
+            ],
+          },
+        },
+        "RoleArn": Object {
+          "Fn::GetAtt": Array [
+            "TestStateMachineRole",
+            "Arn",
+          ],
+        },
+        "Tags": Array [
+          Object {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM",
+          },
+        ],
+      },
+      "Type": "AWS::StepFunctions::StateMachine",
+    },
+    "TestStateMachineRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "states.amazonaws.com",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [],
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "lambda:InvokeFunction",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Sub": Array [
+                      "arn:\${AWS::Partition}:lambda:\${AWS::Region}:\${AWS::AccountId}:function:\${functionName}*",
+                      Object {
+                        "functionName": Object {
+                          "Ref": "hello",
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            "PolicyName": "TestStateMachineRolePolicy0",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "lambda:InvokeFunction",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Sub": Array [
+                      "arn:\${AWS::Partition}:lambda:\${AWS::Region}:\${AWS::AccountId}:function:\${functionName}*",
+                      Object {
+                        "functionName": Object {
+                          "Ref": "hello",
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            "PolicyName": "TestStateMachineRolePolicy1",
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "stateMachine:createdBy",
+            "Value": "SAM",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "throttler": Object {
+      "Metadata": Object {
+        "SamResourceId": "throttler",
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": "aws-sam-cli-managed-default-samclisourcebucket-167xnalzxxva4",
+          "S3Key": "sam-test-project/841a60f2d379216bd90fa34e033d0596",
+        },
+        "Handler": "basic-handler.hello",
+        "ReservedConcurrentExecutions": 0,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "throttlerRole",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": Array [
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+        ],
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "throttlerRole": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "sts:AssumeRole",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Array [
+                  "lambda.amazonaws.com",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "lambda:createdBy",
+            "Value": "SAM",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "vpc": Object {
+      "Metadata": Object {
+        "SamResourceId": "vpc",
+      },
+      "Properties": Object {
+        "CidrBlock": "10.0.0.0/16",
+      },
+      "Type": "AWS::EC2::VPC",
+    },
+  },
+}
+`

--- a/tap-snapshots/serverless-test-project-alb/tests/snapshot/serverless-test-project-alb-snapshot.test.ts.test.cjs
+++ b/tap-snapshots/serverless-test-project-alb/tests/snapshot/serverless-test-project-alb-snapshot.test.ts.test.cjs
@@ -1,0 +1,547 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`serverless-test-project-alb/tests/snapshot/serverless-test-project-alb-snapshot.test.ts > TAP > serverless-test-project-alb snapshot > serverless-test-project-alb template 1`] = `
+Object {
+  "alb": Object {
+    "Properties": Object {
+      "Name": "awesome-loadBalancer",
+      "SecurityGroups": Array [
+        Object {
+          "Ref": "albSecurityGroup",
+        },
+      ],
+      "Subnets": Array [
+        Object {
+          "Ref": "subnetA",
+        },
+        Object {
+          "Ref": "subnetB",
+        },
+      ],
+      "Type": "application",
+    },
+    "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+  },
+  "AlbEventAlbListenerRule1": Object {
+    "Properties": Object {
+      "Actions": Array [
+        Object {
+          "TargetGroupArn": Object {
+            "Ref": "AlbEventAlbTargetGrouphttpListener",
+          },
+          "Type": "forward",
+        },
+      ],
+      "Conditions": Array [
+        Object {
+          "Field": "path-pattern",
+          "Values": Array [
+            "/handleALB",
+          ],
+        },
+        Object {
+          "Field": "http-request-method",
+          "HttpRequestMethodConfig": Object {
+            "Values": Array [
+              "POST",
+            ],
+          },
+        },
+      ],
+      "ListenerArn": Object {
+        "Ref": "httpListener",
+      },
+      "Priority": 1,
+    },
+    "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+  },
+  "AlbEventAlbTargetGrouphttpListener": Object {
+    "DependsOn": Array [
+      "AlbEventLambdaPermissionRegisterTarget",
+    ],
+    "Properties": Object {
+      "HealthCheckEnabled": true,
+      "HealthCheckIntervalSeconds": 35,
+      "HealthCheckPath": "/",
+      "HealthCheckTimeoutSeconds": 30,
+      "HealthyThresholdCount": 5,
+      "Matcher": Object {
+        "HttpCode": "200",
+      },
+      "Name": "1d5fdfd5099ec257209ef7b7c5ee8cb4",
+      "Tags": Array [
+        Object {
+          "Key": "Name",
+          "Value": "serverless-test-project-alb-albEvent-httpListener-dev",
+        },
+      ],
+      "TargetGroupAttributes": Array [
+        Object {
+          "Key": "lambda.multi_value_headers.enabled",
+          "Value": false,
+        },
+      ],
+      "Targets": Array [
+        Object {
+          "Id": Object {
+            "Fn::GetAtt": Array [
+              "AlbEventLambdaFunction",
+              "Arn",
+            ],
+          },
+        },
+      ],
+      "TargetType": "lambda",
+      "UnhealthyThresholdCount": 5,
+    },
+    "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+  },
+  "AlbEventLambdaFunction": Object {
+    "DependsOn": Array [
+      "AlbEventLogGroup",
+    ],
+    "Metadata": Object {
+      "slicWatch": Object {},
+    },
+    "Properties": Object {
+      "Code": Object {
+        "S3Bucket": Object {
+          "Ref": "ServerlessDeploymentBucket",
+        },
+        "S3Key": "serverless/serverless-test-project-alb/dev/1701242684385-2023-11-29T07:24:44.385Z/serverless-test-project-alb.zip",
+      },
+      "FunctionName": "serverless-test-project-alb-dev-albEvent",
+      "Handler": "alb-handler.handleALB",
+      "MemorySize": 1024,
+      "Role": Object {
+        "Fn::GetAtt": Array [
+          "IamRoleLambdaExecution",
+          "Arn",
+        ],
+      },
+      "Runtime": "nodejs18.x",
+      "Timeout": 6,
+    },
+    "Type": "AWS::Lambda::Function",
+  },
+  "AlbEventLambdaPermissionAlb": Object {
+    "Properties": Object {
+      "Action": "lambda:InvokeFunction",
+      "FunctionName": Object {
+        "Fn::GetAtt": Array [
+          "AlbEventLambdaFunction",
+          "Arn",
+        ],
+      },
+      "Principal": "elasticloadbalancing.amazonaws.com",
+      "SourceArn": Object {
+        "Ref": "AlbEventAlbTargetGrouphttpListener",
+      },
+    },
+    "Type": "AWS::Lambda::Permission",
+  },
+  "AlbEventLambdaPermissionRegisterTarget": Object {
+    "Properties": Object {
+      "Action": "lambda:InvokeFunction",
+      "FunctionName": Object {
+        "Fn::GetAtt": Array [
+          "AlbEventLambdaFunction",
+          "Arn",
+        ],
+      },
+      "Principal": "elasticloadbalancing.amazonaws.com",
+    },
+    "Type": "AWS::Lambda::Permission",
+  },
+  "AlbEventLambdaVersion0XznAenLykwY99KhRhuWhGA2GO8nTdlRqGtjPoaDgg": Object {
+    "DeletionPolicy": "Retain",
+    "Properties": Object {
+      "CodeSha256": "iF0ZcJ5dWZd/RnBzvEqO7WAQlHbLsco8p4dUx4U7AL8=",
+      "FunctionName": Object {
+        "Ref": "AlbEventLambdaFunction",
+      },
+    },
+    "Type": "AWS::Lambda::Version",
+  },
+  "AlbEventLogGroup": Object {
+    "Properties": Object {
+      "LogGroupName": "/aws/lambda/serverless-test-project-alb-dev-albEvent",
+    },
+    "Type": "AWS::Logs::LogGroup",
+  },
+  "albSecurityGroup": Object {
+    "Properties": Object {
+      "GroupDescription": "Allow http to client host",
+      "SecurityGroupIngress": Array [
+        Object {
+          "CidrIp": "0.0.0.0/0",
+          "FromPort": 80,
+          "IpProtocol": "tcp",
+          "ToPort": 80,
+        },
+        Object {
+          "CidrIp": "0.0.0.0/0",
+          "FromPort": 443,
+          "IpProtocol": "tcp",
+          "ToPort": 443,
+        },
+      ],
+      "VpcId": Object {
+        "Ref": "vpcALB",
+      },
+    },
+    "Type": "AWS::EC2::SecurityGroup",
+  },
+  "bucket": Object {
+    "Type": "AWS::S3::Bucket",
+  },
+  "httpListener": Object {
+    "Properties": Object {
+      "DefaultActions": Array [
+        Object {
+          "RedirectConfig": Object {
+            "Host": "#{host}",
+            "Path": "/#{path}",
+            "Port": 400,
+            "Protocol": "HTTP",
+            "Query": "#{query}",
+            "StatusCode": "HTTP_301",
+          },
+          "Type": "redirect",
+        },
+      ],
+      "LoadBalancerArn": Object {
+        "Ref": "alb",
+      },
+      "Port": 80,
+      "Protocol": "HTTP",
+    },
+    "Type": "AWS::ElasticLoadBalancingV2::Listener",
+  },
+  "IamRoleLambdaExecution": Object {
+    "Properties": Object {
+      "AssumeRolePolicyDocument": Object {
+        "Statement": Array [
+          Object {
+            "Action": Array [
+              "sts:AssumeRole",
+            ],
+            "Effect": "Allow",
+            "Principal": Object {
+              "Service": Array [
+                "lambda.amazonaws.com",
+              ],
+            },
+          },
+        ],
+        "Version": "2012-10-17",
+      },
+      "Path": "/",
+      "Policies": Array [
+        Object {
+          "PolicyDocument": Object {
+            "Statement": Array [
+              Object {
+                "Action": Array [
+                  "logs:CreateLogStream",
+                  "logs:CreateLogGroup",
+                  "logs:TagResource",
+                ],
+                "Effect": "Allow",
+                "Resource": Array [
+                  Object {
+                    "Fn::Sub": "arn:\${AWS::Partition}:logs:\${AWS::Region}:\${AWS::AccountId}:log-group:/aws/lambda/serverless-test-project-alb-dev*:*",
+                  },
+                ],
+              },
+              Object {
+                "Action": Array [
+                  "logs:PutLogEvents",
+                ],
+                "Effect": "Allow",
+                "Resource": Array [
+                  Object {
+                    "Fn::Sub": "arn:\${AWS::Partition}:logs:\${AWS::Region}:\${AWS::AccountId}:log-group:/aws/lambda/serverless-test-project-alb-dev*:*:*",
+                  },
+                ],
+              },
+            ],
+            "Version": "2012-10-17",
+          },
+          "PolicyName": Object {
+            "Fn::Join": Array [
+              "-",
+              Array [
+                "serverless-test-project-alb",
+                "dev",
+                "lambda",
+              ],
+            ],
+          },
+        },
+      ],
+      "RoleName": Object {
+        "Fn::Join": Array [
+          "-",
+          Array [
+            "serverless-test-project-alb",
+            "dev",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "lambdaRole",
+          ],
+        ],
+      },
+    },
+    "Type": "AWS::IAM::Role",
+  },
+  "internetGateway": Object {
+    "Properties": Object {
+      "Tags": Array [
+        Object {
+          "Key": "ProjectName",
+          "Value": "serverless-test-project-alb",
+        },
+        Object {
+          "Key": "Stage",
+          "Value": "dev",
+        },
+      ],
+    },
+    "Type": "AWS::EC2::InternetGateway",
+  },
+  "routeTableA": Object {
+    "Properties": Object {
+      "Tags": Array [
+        Object {
+          "Key": "ProjectName",
+          "Value": "serverless-test-project-alb",
+        },
+        Object {
+          "Key": "Stage",
+          "Value": "dev",
+        },
+      ],
+      "VpcId": Object {
+        "Ref": "vpcALB",
+      },
+    },
+    "Type": "AWS::EC2::RouteTable",
+  },
+  "routeTableAInternetRoute": Object {
+    "DependsOn": Array [
+      "vpcGatewayAttachment",
+    ],
+    "Properties": Object {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "GatewayId": Object {
+        "Ref": "internetGateway",
+      },
+      "RouteTableId": Object {
+        "Ref": "routeTableA",
+      },
+    },
+    "Type": "AWS::EC2::Route",
+  },
+  "routeTableAssociationSubnetA": Object {
+    "Properties": Object {
+      "RouteTableId": Object {
+        "Ref": "routeTableA",
+      },
+      "SubnetId": Object {
+        "Ref": "subnetA",
+      },
+    },
+    "Type": "AWS::EC2::SubnetRouteTableAssociation",
+  },
+  "routeTableAssociationSubnetB": Object {
+    "Properties": Object {
+      "RouteTableId": Object {
+        "Ref": "routeTableB",
+      },
+      "SubnetId": Object {
+        "Ref": "subnetB",
+      },
+    },
+    "Type": "AWS::EC2::SubnetRouteTableAssociation",
+  },
+  "routeTableB": Object {
+    "Properties": Object {
+      "Tags": Array [
+        Object {
+          "Key": "ProjectName",
+          "Value": "serverless-test-project-alb",
+        },
+        Object {
+          "Key": "Stage",
+          "Value": "dev",
+        },
+      ],
+      "VpcId": Object {
+        "Ref": "vpcALB",
+      },
+    },
+    "Type": "AWS::EC2::RouteTable",
+  },
+  "routeTableBInternetRoute": Object {
+    "DependsOn": Array [
+      "vpcGatewayAttachment",
+    ],
+    "Properties": Object {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "GatewayId": Object {
+        "Ref": "internetGateway",
+      },
+      "RouteTableId": Object {
+        "Ref": "routeTableB",
+      },
+    },
+    "Type": "AWS::EC2::Route",
+  },
+  "ServerlessDeploymentBucket": Object {
+    "Properties": Object {
+      "BucketEncryption": Object {
+        "ServerSideEncryptionConfiguration": Array [
+          Object {
+            "ServerSideEncryptionByDefault": Object {
+              "SSEAlgorithm": "AES256",
+            },
+          },
+        ],
+      },
+    },
+    "Type": "AWS::S3::Bucket",
+  },
+  "ServerlessDeploymentBucketPolicy": Object {
+    "Properties": Object {
+      "Bucket": Object {
+        "Ref": "ServerlessDeploymentBucket",
+      },
+      "PolicyDocument": Object {
+        "Statement": Array [
+          Object {
+            "Action": "s3:*",
+            "Condition": Object {
+              "Bool": Object {
+                "aws:SecureTransport": false,
+              },
+            },
+            "Effect": "Deny",
+            "Principal": "*",
+            "Resource": Array [
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::",
+                    Object {
+                      "Ref": "ServerlessDeploymentBucket",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::",
+                    Object {
+                      "Ref": "ServerlessDeploymentBucket",
+                    },
+                  ],
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    },
+    "Type": "AWS::S3::BucketPolicy",
+  },
+  "subnetA": Object {
+    "Properties": Object {
+      "AvailabilityZone": "eu-west-1a",
+      "CidrBlock": "10.0.5.0/24",
+      "Tags": Array [
+        Object {
+          "Key": "ProjectName",
+          "Value": "serverless-test-project-alb",
+        },
+        Object {
+          "Key": "Stage",
+          "Value": "dev",
+        },
+      ],
+      "VpcId": Object {
+        "Ref": "vpcALB",
+      },
+    },
+    "Type": "AWS::EC2::Subnet",
+  },
+  "subnetB": Object {
+    "Properties": Object {
+      "AvailabilityZone": "eu-west-1b",
+      "CidrBlock": "10.0.6.0/24",
+      "Tags": Array [
+        Object {
+          "Key": "ProjectName",
+          "Value": "serverless-test-project-alb",
+        },
+        Object {
+          "Key": "Stage",
+          "Value": "dev",
+        },
+      ],
+      "VpcId": Object {
+        "Ref": "vpcALB",
+      },
+    },
+    "Type": "AWS::EC2::Subnet",
+  },
+  "vpcALB": Object {
+    "Properties": Object {
+      "CidrBlock": "10.0.0.0/20",
+      "EnableDnsHostnames": true,
+      "EnableDnsSupport": true,
+      "InstanceTenancy": "default",
+      "Tags": Array [
+        Object {
+          "Key": "ProjectName",
+          "Value": "serverless-test-project-alb",
+        },
+        Object {
+          "Key": "Stage",
+          "Value": "dev",
+        },
+      ],
+    },
+    "Type": "AWS::EC2::VPC",
+  },
+  "vpcGatewayAttachment": Object {
+    "Properties": Object {
+      "InternetGatewayId": Object {
+        "Ref": "internetGateway",
+      },
+      "VpcId": Object {
+        "Ref": "vpcALB",
+      },
+    },
+    "Type": "AWS::EC2::VPCGatewayAttachment",
+  },
+}
+`

--- a/tap-snapshots/serverless-test-project-appsync/tests/snapshot/serverless-test-project-appsync-snapshot.test.ts.test.cjs
+++ b/tap-snapshots/serverless-test-project-appsync/tests/snapshot/serverless-test-project-appsync-snapshot.test.ts.test.cjs
@@ -1,0 +1,553 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`serverless-test-project-appsync/tests/snapshot/serverless-test-project-appsync-snapshot.test.ts > TAP > serverless-test-project-appsync snapshot > serverless-test-project-appsync template 1`] = `
+Object {
+  "AwesomeappsyncGraphQlApi": Object {
+    "Properties": Object {
+      "AdditionalAuthenticationProviders": Array [],
+      "AuthenticationType": "AMAZON_COGNITO_USER_POOLS",
+      "Name": "awesome-appsync",
+      "UserPoolConfig": Object {
+        "AwsRegion": "eu-west-1",
+        "DefaultAction": "ALLOW",
+        "UserPoolId": Object {
+          "Ref": "CognitoUserPool",
+        },
+      },
+      "XrayEnabled": false,
+    },
+    "Type": "AWS::AppSync::GraphQLApi",
+  },
+  "AwesomeappsyncGraphQlDsbooksTable": Object {
+    "Properties": Object {
+      "ApiId": Object {
+        "Fn::GetAtt": Array [
+          "AwesomeappsyncGraphQlApi",
+          "ApiId",
+        ],
+      },
+      "DynamoDBConfig": Object {
+        "AwsRegion": "eu-west-1",
+        "TableName": Object {
+          "Ref": "BooksTable",
+        },
+        "UseCallerCredentials": false,
+        "Versioned": false,
+      },
+      "Name": "booksTable",
+      "ServiceRoleArn": Object {
+        "Fn::GetAtt": Array [
+          "AwesomeappsyncGraphQlDsbooksTableRole",
+          "Arn",
+        ],
+      },
+      "Type": "AMAZON_DYNAMODB",
+    },
+    "Type": "AWS::AppSync::DataSource",
+  },
+  "AwesomeappsyncGraphQlDsbooksTableRole": Object {
+    "Properties": Object {
+      "AssumeRolePolicyDocument": Object {
+        "Statement": Array [
+          Object {
+            "Action": Array [
+              "sts:AssumeRole",
+            ],
+            "Effect": "Allow",
+            "Principal": Object {
+              "Service": Array [
+                "appsync.amazonaws.com",
+              ],
+            },
+          },
+        ],
+        "Version": "2012-10-17",
+      },
+      "Policies": Array [
+        Object {
+          "PolicyDocument": Object {
+            "Statement": Array [
+              Object {
+                "Action": Array [
+                  "dynamodb:DeleteItem",
+                  "dynamodb:GetItem",
+                  "dynamodb:PutItem",
+                  "dynamodb:Query",
+                  "dynamodb:Scan",
+                  "dynamodb:UpdateItem",
+                  "dynamodb:BatchGetItem",
+                  "dynamodb:BatchWriteItem",
+                  "dynamodb:ConditionCheckItem",
+                ],
+                "Effect": "Allow",
+                "Resource": Array [
+                  Object {
+                    "Fn::Join": Array [
+                      ":",
+                      Array [
+                        "arn",
+                        "aws",
+                        "dynamodb",
+                        "eu-west-1",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        Object {
+                          "Fn::Join": Array [
+                            "/",
+                            Array [
+                              "table",
+                              Object {
+                                "Ref": "BooksTable",
+                              },
+                            ],
+                          ],
+                        },
+                      ],
+                    ],
+                  },
+                  Object {
+                    "Fn::Join": Array [
+                      "/",
+                      Array [
+                        Object {
+                          "Fn::Join": Array [
+                            ":",
+                            Array [
+                              "arn",
+                              "aws",
+                              "dynamodb",
+                              "eu-west-1",
+                              Object {
+                                "Ref": "AWS::AccountId",
+                              },
+                              Object {
+                                "Fn::Join": Array [
+                                  "/",
+                                  Array [
+                                    "table",
+                                    Object {
+                                      "Ref": "BooksTable",
+                                    },
+                                  ],
+                                ],
+                              },
+                            ],
+                          ],
+                        },
+                        "*",
+                      ],
+                    ],
+                  },
+                ],
+              },
+            ],
+            "Version": "2012-10-17",
+          },
+          "PolicyName": "GraphQlDsbooksTablePolicy",
+        },
+      ],
+    },
+    "Type": "AWS::IAM::Role",
+  },
+  "AwesomeappsyncGraphQlResolverMutationcreateBook": Object {
+    "DependsOn": "AwesomeappsyncGraphQlSchema",
+    "Properties": Object {
+      "ApiId": Object {
+        "Fn::GetAtt": Array [
+          "AwesomeappsyncGraphQlApi",
+          "ApiId",
+        ],
+      },
+      "DataSourceName": Object {
+        "Fn::GetAtt": Array [
+          "AwesomeappsyncGraphQlDsbooksTable",
+          "Name",
+        ],
+      },
+      "FieldName": "createBook",
+      "Kind": "UNIT",
+      "RequestMappingTemplate": String(
+        {
+            "version" : "2018-05-29",
+            "operation" : "PutItem",
+            "key": {
+                "bookId" : $util.dynamodb.toDynamoDBJson($util.autoId())
+            },
+            "attributeValues" : {
+                "title" : $util.dynamodb.toDynamoDBJson($context.arguments.newBook.title),
+                "description" : $util.dynamodb.toDynamoDBJson($context.arguments.newBook.description),
+                "imageUrl" : $util.dynamodb.toDynamoDBJson($context.arguments.newBook.imageUrl),
+                "author" : $util.dynamodb.toDynamoDBJson($context.arguments.newBook.author),
+                "price" : $util.dynamodb.toDynamoDBJson($context.arguments.newBook.price),
+                "createdAt": $util.dynamodb.toDynamoDBJson($util.time.nowISO8601()),
+                "updatedAt": $util.dynamodb.toDynamoDBJson($util.time.nowISO8601())
+            }
+        }
+      ),
+      "ResponseMappingTemplate": "$util.toJson($context.result)",
+      "TypeName": "Mutation",
+    },
+    "Type": "AWS::AppSync::Resolver",
+  },
+  "AwesomeappsyncGraphQlResolverQuerygetBookById": Object {
+    "DependsOn": "AwesomeappsyncGraphQlSchema",
+    "Properties": Object {
+      "ApiId": Object {
+        "Fn::GetAtt": Array [
+          "AwesomeappsyncGraphQlApi",
+          "ApiId",
+        ],
+      },
+      "DataSourceName": Object {
+        "Fn::GetAtt": Array [
+          "AwesomeappsyncGraphQlDsbooksTable",
+          "Name",
+        ],
+      },
+      "FieldName": "getBookById",
+      "Kind": "UNIT",
+      "RequestMappingTemplate": String(
+        #if ($context.info.selectionSetList.size() == 1 && $context.info.selectionSetList[0] == "id")
+          #set ($result = { "id": "$context.source.otherUserId" })
+        
+          #return($result)
+        #end
+        
+        {
+          "version" : "2018-05-29",
+          "operation" : "GetItem",
+          "key" : {
+            "bookId" : $util.dynamodb.toDynamoDBJson($context.arguments.bookId)
+          }
+        }
+      ),
+      "ResponseMappingTemplate": "$util.toJson($context.result)",
+      "TypeName": "Query",
+    },
+    "Type": "AWS::AppSync::Resolver",
+  },
+  "AwesomeappsyncGraphQlSchema": Object {
+    "Properties": Object {
+      "ApiId": Object {
+        "Fn::GetAtt": Array [
+          "AwesomeappsyncGraphQlApi",
+          "ApiId",
+        ],
+      },
+      "Definition": String(
+        schema {
+          query: Query
+          mutation: Mutation
+          subscription: Subscription
+        }
+        
+        type Subscription {
+          onCreateBook: Book @aws_subscribe(mutations: ["createBook"])
+        }
+        
+        type Query {
+          getBookById(bookId: ID!): Book!
+        }
+        
+        type Book {
+          bookId: ID!
+          title: String!
+          description: String
+          imageUrl: AWSURL
+          author: String!
+          price: Float!
+          createdAt: AWSDateTime!
+          updatedAt: AWSDateTime!
+        }
+        
+        type Mutation {
+          createBook(newBook: BookInput): Book! @aws_auth(cognito_groups: ["Admin"])
+        }
+        
+        input BookInput {
+          title: String!
+          description: String
+          imageUrl: AWSURL
+          author: String!
+          price: Float!
+        }
+      ),
+    },
+    "Type": "AWS::AppSync::GraphQLSchema",
+  },
+  "BooksTable": Object {
+    "Properties": Object {
+      "AttributeDefinitions": Array [
+        Object {
+          "AttributeName": "bookId",
+          "AttributeType": "S",
+        },
+      ],
+      "BillingMode": "PAY_PER_REQUEST",
+      "KeySchema": Array [
+        Object {
+          "AttributeName": "bookId",
+          "KeyType": "HASH",
+        },
+      ],
+      "Tags": Array [
+        Object {
+          "Key": "Name",
+          "Value": "books-table",
+        },
+      ],
+    },
+    "Type": "AWS::DynamoDB::Table",
+  },
+  "bucket": Object {
+    "Type": "AWS::S3::Bucket",
+  },
+  "CognitoAdminGroup": Object {
+    "Properties": Object {
+      "Description": "Admin users belong to this group",
+      "GroupName": "Admin",
+      "RoleArn": Object {
+        "Fn::GetAtt": Array [
+          "CognitoAdminIAMrole",
+          "Arn",
+        ],
+      },
+      "UserPoolId": Object {
+        "Ref": "CognitoUserPool",
+      },
+    },
+    "Type": "AWS::Cognito::UserPoolGroup",
+  },
+  "CognitoAdminIAMrole": Object {
+    "Properties": Object {
+      "AssumeRolePolicyDocument": Object {
+        "Statement": Array [
+          Object {
+            "Action": Array [
+              "sts:AssumeRoleWithWebIdentity",
+            ],
+            "Effect": "Allow",
+            "Principal": Object {
+              "Federated": Array [
+                "cognito-identity.amazonaws.com",
+              ],
+            },
+          },
+        ],
+        "Version": "2012-10-17",
+      },
+      "Description": "This is the IAM role that admin group users name",
+      "Policies": Array [
+        Object {
+          "PolicyDocument": Object {
+            "Statement": Array [
+              Object {
+                "Action": Array [
+                  "dynamodb:*",
+                ],
+                "Effect": "Allow",
+                "Resource": Array [
+                  Object {
+                    "Fn::GetAtt": Array [
+                      "BooksTable",
+                      "Arn",
+                    ],
+                  },
+                ],
+              },
+            ],
+            "Version": "2012-10-17",
+          },
+          "PolicyName": "bookstore-admin-group-policy",
+        },
+      ],
+      "RoleName": "bookstore-admin-role",
+    },
+    "Type": "AWS::IAM::Role",
+  },
+  "CognitoCustomerGroup": Object {
+    "Properties": Object {
+      "Description": "Customer belongs to this group",
+      "GroupName": "Customer",
+      "RoleArn": Object {
+        "Fn::GetAtt": Array [
+          "CognitoUserIAMrole",
+          "Arn",
+        ],
+      },
+      "UserPoolId": Object {
+        "Ref": "CognitoUserPool",
+      },
+    },
+    "Type": "AWS::Cognito::UserPoolGroup",
+  },
+  "CognitoUserIAMrole": Object {
+    "Properties": Object {
+      "AssumeRolePolicyDocument": Object {
+        "Statement": Array [
+          Object {
+            "Action": Array [
+              "sts:AssumeRoleWithWebIdentity",
+            ],
+            "Effect": "Allow",
+            "Principal": Object {
+              "Federated": Array [
+                "cognito-identity.amazonaws.com",
+              ],
+            },
+          },
+        ],
+        "Version": "2012-10-17",
+      },
+      "Description": "This is the IAM role that admin group users name",
+      "Policies": Array [
+        Object {
+          "PolicyDocument": Object {
+            "Statement": Array [
+              Object {
+                "Action": Array [
+                  "dynamodb:GetItem",
+                  "dynamodb:Query",
+                  "dynamodb:BatchGetItem",
+                ],
+                "Effect": "Allow",
+                "Resource": Array [
+                  Object {
+                    "Fn::GetAtt": Array [
+                      "BooksTable",
+                      "Arn",
+                    ],
+                  },
+                ],
+              },
+            ],
+            "Version": "2012-10-17",
+          },
+          "PolicyName": "book-store-customer-group-policy",
+        },
+      ],
+      "RoleName": "bookstore-customer-role",
+    },
+    "Type": "AWS::IAM::Role",
+  },
+  "CognitoUserPool": Object {
+    "Properties": Object {
+      "AutoVerifiedAttributes": Array [
+        "email",
+      ],
+      "Policies": Object {
+        "PasswordPolicy": Object {
+          "MinimumLength": 8,
+          "RequireLowercase": false,
+          "RequireNumbers": false,
+          "RequireSymbols": false,
+          "RequireUppercase": false,
+        },
+      },
+      "Schema": Array [
+        Object {
+          "AttributeDataType": "String",
+          "Mutable": true,
+          "Name": "name",
+          "Required": false,
+        },
+      ],
+      "UsernameAttributes": Array [
+        "email",
+      ],
+      "UserPoolName": "BookStoreUserPool",
+    },
+    "Type": "AWS::Cognito::UserPool",
+  },
+  "CognitoUserPoolClient": Object {
+    "Properties": Object {
+      "ClientName": "web",
+      "ExplicitAuthFlows": Array [
+        "ALLOW_USER_SRP_AUTH",
+        "ALLOW_USER_PASSWORD_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
+      ],
+      "PreventUserExistenceErrors": "ENABLED",
+      "UserPoolId": Object {
+        "Ref": "CognitoUserPool",
+      },
+    },
+    "Type": "AWS::Cognito::UserPoolClient",
+  },
+  "ServerlessDeploymentBucket": Object {
+    "Properties": Object {
+      "BucketEncryption": Object {
+        "ServerSideEncryptionConfiguration": Array [
+          Object {
+            "ServerSideEncryptionByDefault": Object {
+              "SSEAlgorithm": "AES256",
+            },
+          },
+        ],
+      },
+    },
+    "Type": "AWS::S3::Bucket",
+  },
+  "ServerlessDeploymentBucketPolicy": Object {
+    "Properties": Object {
+      "Bucket": Object {
+        "Ref": "ServerlessDeploymentBucket",
+      },
+      "PolicyDocument": Object {
+        "Statement": Array [
+          Object {
+            "Action": "s3:*",
+            "Condition": Object {
+              "Bool": Object {
+                "aws:SecureTransport": false,
+              },
+            },
+            "Effect": "Deny",
+            "Principal": "*",
+            "Resource": Array [
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::",
+                    Object {
+                      "Ref": "ServerlessDeploymentBucket",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::",
+                    Object {
+                      "Ref": "ServerlessDeploymentBucket",
+                    },
+                  ],
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    },
+    "Type": "AWS::S3::BucketPolicy",
+  },
+}
+`

--- a/tap-snapshots/serverless-test-project/tests/snapshot/serverless-test-project-snapshot.test.ts.test.cjs
+++ b/tap-snapshots/serverless-test-project/tests/snapshot/serverless-test-project-snapshot.test.ts.test.cjs
@@ -1,0 +1,1505 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`serverless-test-project/tests/snapshot/serverless-test-project-snapshot.test.ts > TAP > serverless-test-project snapshot > serverless-test-project template 1`] = `
+Object {
+  "ApiGatewayDeployment1701242215363": Object {
+    "DependsOn": Array [
+      "ApiGatewayMethodItemGet",
+      "ApiGatewayMethodSubscriptionPost",
+    ],
+    "Properties": Object {
+      "RestApiId": Object {
+        "Ref": "ApiGatewayRestApi",
+      },
+      "StageName": "dev",
+    },
+    "Type": "AWS::ApiGateway::Deployment",
+  },
+  "ApiGatewayMethodItemGet": Object {
+    "DependsOn": Array [
+      "HttpGetterLambdaPermissionApiGateway",
+    ],
+    "Properties": Object {
+      "ApiKeyRequired": false,
+      "AuthorizationType": "NONE",
+      "HttpMethod": "GET",
+      "Integration": Object {
+        "IntegrationHttpMethod": "POST",
+        "Type": "AWS_PROXY",
+        "Uri": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              Object {
+                "Fn::GetAtt": Array [
+                  "HttpGetterLambdaFunction",
+                  "Arn",
+                ],
+              },
+              "/invocations",
+            ],
+          ],
+        },
+      },
+      "MethodResponses": Array [],
+      "RequestParameters": Object {},
+      "ResourceId": Object {
+        "Ref": "ApiGatewayResourceItem",
+      },
+      "RestApiId": Object {
+        "Ref": "ApiGatewayRestApi",
+      },
+    },
+    "Type": "AWS::ApiGateway::Method",
+  },
+  "ApiGatewayMethodSubscriptionPost": Object {
+    "DependsOn": Array [
+      "SubscriptionHandlerLambdaPermissionApiGateway",
+    ],
+    "Properties": Object {
+      "ApiKeyRequired": false,
+      "AuthorizationType": "NONE",
+      "HttpMethod": "POST",
+      "Integration": Object {
+        "IntegrationHttpMethod": "POST",
+        "Type": "AWS_PROXY",
+        "Uri": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "arn:",
+              Object {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              Object {
+                "Fn::GetAtt": Array [
+                  "SubscriptionHandlerLambdaFunction",
+                  "Arn",
+                ],
+              },
+              "/invocations",
+            ],
+          ],
+        },
+      },
+      "MethodResponses": Array [],
+      "RequestParameters": Object {},
+      "ResourceId": Object {
+        "Ref": "ApiGatewayResourceSubscription",
+      },
+      "RestApiId": Object {
+        "Ref": "ApiGatewayRestApi",
+      },
+    },
+    "Type": "AWS::ApiGateway::Method",
+  },
+  "ApiGatewayResourceItem": Object {
+    "Properties": Object {
+      "ParentId": Object {
+        "Fn::GetAtt": Array [
+          "ApiGatewayRestApi",
+          "RootResourceId",
+        ],
+      },
+      "PathPart": "item",
+      "RestApiId": Object {
+        "Ref": "ApiGatewayRestApi",
+      },
+    },
+    "Type": "AWS::ApiGateway::Resource",
+  },
+  "ApiGatewayResourceSubscription": Object {
+    "Properties": Object {
+      "ParentId": Object {
+        "Fn::GetAtt": Array [
+          "ApiGatewayRestApi",
+          "RootResourceId",
+        ],
+      },
+      "PathPart": "subscription",
+      "RestApiId": Object {
+        "Ref": "ApiGatewayRestApi",
+      },
+    },
+    "Type": "AWS::ApiGateway::Resource",
+  },
+  "ApiGatewayRestApi": Object {
+    "Properties": Object {
+      "EndpointConfiguration": Object {
+        "Types": Array [
+          "REGIONAL",
+        ],
+      },
+      "Name": "dev-serverless-test-project",
+      "Policy": "",
+    },
+    "Type": "AWS::ApiGateway::RestApi",
+  },
+  "bucket": Object {
+    "Properties": Object {
+      "BucketName": Object {
+        "Fn::Sub": "slic-watch-test-project-bucket-\${AWS::AccountId}-\${AWS::Region}",
+      },
+    },
+    "Type": "AWS::S3::Bucket",
+  },
+  "dataTable": Object {
+    "DeletionPolicy": "Delete",
+    "Properties": Object {
+      "AttributeDefinitions": Array [
+        Object {
+          "AttributeName": "pk",
+          "AttributeType": "S",
+        },
+        Object {
+          "AttributeName": "sk",
+          "AttributeType": "S",
+        },
+        Object {
+          "AttributeName": "gsi1pk",
+          "AttributeType": "S",
+        },
+        Object {
+          "AttributeName": "gsi1sk",
+          "AttributeType": "S",
+        },
+        Object {
+          "AttributeName": "timestamp",
+          "AttributeType": "N",
+        },
+      ],
+      "GlobalSecondaryIndexes": Array [
+        Object {
+          "IndexName": "GSI1",
+          "KeySchema": Array [
+            Object {
+              "AttributeName": "gsi1pk",
+              "KeyType": "HASH",
+            },
+            Object {
+              "AttributeName": "gsi1sk",
+              "KeyType": "RANGE",
+            },
+          ],
+          "Projection": Object {
+            "NonKeyAttributes": Array [
+              "address",
+            ],
+            "ProjectionType": "INCLUDE",
+          },
+          "ProvisionedThroughput": Object {
+            "ReadCapacityUnits": 1,
+            "WriteCapacityUnits": 1,
+          },
+        },
+      ],
+      "KeySchema": Array [
+        Object {
+          "AttributeName": "pk",
+          "KeyType": "HASH",
+        },
+        Object {
+          "AttributeName": "sk",
+          "KeyType": "RANGE",
+        },
+      ],
+      "LocalSecondaryIndexes": Array [
+        Object {
+          "IndexName": "LSI1",
+          "KeySchema": Array [
+            Object {
+              "AttributeName": "pk",
+              "KeyType": "HASH",
+            },
+            Object {
+              "AttributeName": "timestamp",
+              "KeyType": "RANGE",
+            },
+          ],
+          "Projection": Object {
+            "NonKeyAttributes": Array [
+              "name",
+            ],
+            "ProjectionType": "INCLUDE",
+          },
+        },
+      ],
+      "ProvisionedThroughput": Object {
+        "ReadCapacityUnits": 1,
+        "WriteCapacityUnits": 1,
+      },
+      "TableName": "MyTable",
+    },
+    "Type": "AWS::DynamoDB::Table",
+  },
+  "DriveQueueLambdaFunction": Object {
+    "DependsOn": Array [
+      "DriveQueueLogGroup",
+    ],
+    "Metadata": Object {
+      "slicWatch": Object {},
+    },
+    "Properties": Object {
+      "Code": Object {
+        "S3Bucket": Object {
+          "Ref": "ServerlessDeploymentBucket",
+        },
+        "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip",
+      },
+      "FunctionName": "serverless-test-project-dev-driveQueue",
+      "Handler": "queue-test-handler.handleDrive",
+      "MemorySize": 1024,
+      "Role": Object {
+        "Fn::GetAtt": Array [
+          "IamRoleLambdaExecution",
+          "Arn",
+        ],
+      },
+      "Runtime": "nodejs18.x",
+      "Timeout": 6,
+    },
+    "Type": "AWS::Lambda::Function",
+  },
+  "DriveQueueLambdaVersionTmzx8HCxfunJ3etrLOOYLg8zG05MzRauykeVpZFz8WY": Object {
+    "DeletionPolicy": "Retain",
+    "Properties": Object {
+      "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0=",
+      "FunctionName": Object {
+        "Ref": "DriveQueueLambdaFunction",
+      },
+    },
+    "Type": "AWS::Lambda::Version",
+  },
+  "DriveQueueLogGroup": Object {
+    "Properties": Object {
+      "LogGroupName": "/aws/lambda/serverless-test-project-dev-driveQueue",
+    },
+    "Type": "AWS::Logs::LogGroup",
+  },
+  "DriveStreamLambdaFunction": Object {
+    "DependsOn": Array [
+      "DriveStreamLogGroup",
+    ],
+    "Metadata": Object {
+      "slicWatch": Object {},
+    },
+    "Properties": Object {
+      "Code": Object {
+        "S3Bucket": Object {
+          "Ref": "ServerlessDeploymentBucket",
+        },
+        "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip",
+      },
+      "Environment": Object {
+        "Variables": Object {
+          "STREAM_NAME": Object {
+            "Ref": "stream",
+          },
+        },
+      },
+      "FunctionName": "serverless-test-project-dev-driveStream",
+      "Handler": "stream-test-handler.handleDrive",
+      "MemorySize": 1024,
+      "Role": Object {
+        "Fn::GetAtt": Array [
+          "IamRoleLambdaExecution",
+          "Arn",
+        ],
+      },
+      "Runtime": "nodejs18.x",
+      "Timeout": 6,
+    },
+    "Type": "AWS::Lambda::Function",
+  },
+  "DriveStreamLambdaVersionsWkqlV7IV7mJdqIqQToVljMizTzZoDCso7qMazjI": Object {
+    "DeletionPolicy": "Retain",
+    "Properties": Object {
+      "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0=",
+      "FunctionName": Object {
+        "Ref": "DriveStreamLambdaFunction",
+      },
+    },
+    "Type": "AWS::Lambda::Version",
+  },
+  "DriveStreamLogGroup": Object {
+    "Properties": Object {
+      "LogGroupName": "/aws/lambda/serverless-test-project-dev-driveStream",
+    },
+    "Type": "AWS::Logs::LogGroup",
+  },
+  "DriveTableLambdaFunction": Object {
+    "DependsOn": Array [
+      "DriveTableLogGroup",
+    ],
+    "Metadata": Object {
+      "slicWatch": Object {},
+    },
+    "Properties": Object {
+      "Code": Object {
+        "S3Bucket": Object {
+          "Ref": "ServerlessDeploymentBucket",
+        },
+        "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip",
+      },
+      "FunctionName": "serverless-test-project-dev-driveTable",
+      "Handler": "table-test-hander.handleDrive",
+      "MemorySize": 1024,
+      "Role": Object {
+        "Fn::GetAtt": Array [
+          "IamRoleLambdaExecution",
+          "Arn",
+        ],
+      },
+      "Runtime": "nodejs18.x",
+      "Timeout": 6,
+    },
+    "Type": "AWS::Lambda::Function",
+  },
+  "DriveTableLambdaVersionkqI0DCnUasgza04mnCpqj0q5vePTOojYtyi4hxfE3ME": Object {
+    "DeletionPolicy": "Retain",
+    "Properties": Object {
+      "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0=",
+      "FunctionName": Object {
+        "Ref": "DriveTableLambdaFunction",
+      },
+    },
+    "Type": "AWS::Lambda::Version",
+  },
+  "DriveTableLogGroup": Object {
+    "Properties": Object {
+      "LogGroupName": "/aws/lambda/serverless-test-project-dev-driveTable",
+    },
+    "Type": "AWS::Logs::LogGroup",
+  },
+  "ecsCluster": Object {
+    "Properties": Object {
+      "ClusterName": "awesome-cluster",
+    },
+    "Type": "AWS::ECS::Cluster",
+  },
+  "ecsService": Object {
+    "Properties": Object {
+      "Cluster": Object {
+        "Ref": "ecsCluster",
+      },
+      "DesiredCount": 0,
+      "LaunchType": "FARGATE",
+      "NetworkConfiguration": Object {
+        "AwsvpcConfiguration": Object {
+          "AssignPublicIp": "ENABLED",
+          "SecurityGroups": Array [],
+          "Subnets": Array [
+            Object {
+              "Ref": "subnet",
+            },
+          ],
+        },
+      },
+      "ServiceName": "awesome-service",
+      "TaskDefinition": Object {
+        "Ref": "taskDef",
+      },
+    },
+    "Type": "AWS::ECS::Service",
+  },
+  "EventsRuleEventBridgeLambdaPermission1": Object {
+    "Properties": Object {
+      "Action": "lambda:InvokeFunction",
+      "FunctionName": Object {
+        "Fn::GetAtt": Array [
+          "EventsRuleLambdaFunction",
+          "Arn",
+        ],
+      },
+      "Principal": "events.amazonaws.com",
+      "SourceArn": Object {
+        "Fn::Join": Array [
+          ":",
+          Array [
+            "arn",
+            Object {
+              "Ref": "AWS::Partition",
+            },
+            "events",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            Object {
+              "Ref": "AWS::AccountId",
+            },
+            Object {
+              "Fn::Join": Array [
+                "/",
+                Array [
+                  "rule",
+                  "serverless-test-project-dev-eventsRule-rule-1",
+                ],
+              ],
+            },
+          ],
+        ],
+      },
+    },
+    "Type": "AWS::Lambda::Permission",
+  },
+  "EventsRuleLambdaFunction": Object {
+    "DependsOn": Array [
+      "EventsRuleLogGroup",
+    ],
+    "Metadata": Object {
+      "slicWatch": Object {
+        "alarms": Object {
+          "Lambda": Object {
+            "enabled": false,
+          },
+        },
+      },
+    },
+    "Properties": Object {
+      "Code": Object {
+        "S3Bucket": Object {
+          "Ref": "ServerlessDeploymentBucket",
+        },
+        "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip",
+      },
+      "FunctionName": "serverless-test-project-dev-eventsRule",
+      "Handler": "rule-handler.handleRule",
+      "MemorySize": 1024,
+      "Role": Object {
+        "Fn::GetAtt": Array [
+          "IamRoleLambdaExecution",
+          "Arn",
+        ],
+      },
+      "Runtime": "nodejs18.x",
+      "Timeout": 6,
+    },
+    "Type": "AWS::Lambda::Function",
+  },
+  "EventsRuleLambdaVersionxBuN447jfeozyKD2CEV3oCIHhShTUOVe5XKOkBlbchQ": Object {
+    "DeletionPolicy": "Retain",
+    "Properties": Object {
+      "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0=",
+      "FunctionName": Object {
+        "Ref": "EventsRuleLambdaFunction",
+      },
+    },
+    "Type": "AWS::Lambda::Version",
+  },
+  "EventsRuleLogGroup": Object {
+    "Properties": Object {
+      "LogGroupName": "/aws/lambda/serverless-test-project-dev-eventsRule",
+    },
+    "Type": "AWS::Logs::LogGroup",
+  },
+  "ExpressWorkflow": Object {
+    "DependsOn": Array [
+      "ExpressWorkflowRole",
+    ],
+    "Properties": Object {
+      "DefinitionString": Object {
+        "Fn::Sub": Array [
+          String(
+            {
+              "StartAt": "What Next?",
+              "States": {
+                "What Next?": {
+                  "Type": "Choice",
+                  "Choices": [
+                    {
+                      "Variable": "$.destination",
+                      "StringEquals": "fail",
+                      "Next": "Fail"
+                    },
+                    {
+                      "Variable": "$.destination",
+                      "StringEquals": "timeoutTask",
+                      "Next": "TimeoutTask"
+                    },
+                    {
+                      "Variable": "$.destination",
+                      "StringEquals": "keepWaiting",
+                      "Next": "KeepWaiting"
+                    }
+                  ],
+                  "Default": "Succeed"
+                },
+                "TimeoutTask": {
+                  "Type": "Task",
+                  "TimeoutSeconds": 1,
+                  "Resource": "\${085edd942ce144c5bd80364a6e973e4d}",
+                  "Parameters": {
+                    "sleepSeconds": 3
+                  },
+                  "Next": "Succeed"
+                },
+                "KeepWaiting": {
+                  "Type": "Wait",
+                  "Seconds": 1,
+                  "Next": "KeepWaiting"
+                },
+                "Fail": {
+                  "Type": "Fail"
+                },
+                "Succeed": {
+                  "Type": "Pass",
+                  "End": true
+                }
+              }
+            }
+          ),
+          Object {
+            "085edd942ce144c5bd80364a6e973e4d": Object {
+              "Fn::GetAtt": Array [
+                "PingLambdaFunction",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "LoggingConfiguration": Object {
+        "Destinations": Array [
+          Object {
+            "CloudWatchLogsLogGroup": Object {
+              "LogGroupArn": Object {
+                "Fn::GetAtt": Array [
+                  "expressWorkflowLogGroup",
+                  "Arn",
+                ],
+              },
+            },
+          },
+        ],
+        "IncludeExecutionData": true,
+        "Level": "ALL",
+      },
+      "RoleArn": Object {
+        "Fn::GetAtt": Array [
+          "ExpressWorkflowRole",
+          "Arn",
+        ],
+      },
+      "StateMachineName": "ExpressWorkflow",
+      "StateMachineType": "EXPRESS",
+    },
+    "Type": "AWS::StepFunctions::StateMachine",
+  },
+  "expressWorkflowLogGroup": Object {
+    "Properties": Object {
+      "LogGroupName": "ExpressWorkflowLogs",
+      "RetentionInDays": 1,
+    },
+    "Type": "AWS::Logs::LogGroup",
+  },
+  "ExpressWorkflowRole": Object {
+    "Properties": Object {
+      "AssumeRolePolicyDocument": Object {
+        "Statement": Array [
+          Object {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": Object {
+              "Service": Object {
+                "Fn::Sub": "states.\${AWS::Region}.amazonaws.com",
+              },
+            },
+          },
+        ],
+        "Version": "2012-10-17",
+      },
+      "Policies": Array [
+        Object {
+          "PolicyDocument": Object {
+            "Statement": Array [
+              Object {
+                "Action": Array [
+                  "lambda:InvokeFunction",
+                ],
+                "Effect": "Allow",
+                "Resource": Array [
+                  Object {
+                    "Fn::GetAtt": Array [
+                      "PingLambdaFunction",
+                      "Arn",
+                    ],
+                  },
+                  Object {
+                    "Fn::Sub": Array [
+                      "\${functionArn}:*",
+                      Object {
+                        "functionArn": Object {
+                          "Fn::GetAtt": Array [
+                            "PingLambdaFunction",
+                            "Arn",
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              Object {
+                "Action": Array [
+                  "logs:CreateLogDelivery",
+                  "logs:GetLogDelivery",
+                  "logs:UpdateLogDelivery",
+                  "logs:DeleteLogDelivery",
+                  "logs:ListLogDeliveries",
+                  "logs:PutResourcePolicy",
+                  "logs:DescribeResourcePolicies",
+                  "logs:DescribeLogGroups",
+                ],
+                "Effect": "Allow",
+                "Resource": "*",
+              },
+            ],
+            "Version": "2012-10-17",
+          },
+          "PolicyName": "dev-serverless-test-project-statemachine",
+        },
+      ],
+    },
+    "Type": "AWS::IAM::Role",
+  },
+  "fifoQueue": Object {
+    "Properties": Object {
+      "FifoQueue": true,
+      "QueueName": "SomeFifoQueue.fifo",
+    },
+    "Type": "AWS::SQS::Queue",
+  },
+  "HelloLambdaFunction": Object {
+    "DependsOn": Array [
+      "HelloLogGroup",
+    ],
+    "Metadata": Object {
+      "slicWatch": Object {
+        "alarms": Object {
+          "Lambda": Object {
+            "Invocations": Object {
+              "Threshold": 2,
+            },
+          },
+        },
+      },
+    },
+    "Properties": Object {
+      "Code": Object {
+        "S3Bucket": Object {
+          "Ref": "ServerlessDeploymentBucket",
+        },
+        "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip",
+      },
+      "FunctionName": "serverless-test-project-dev-hello",
+      "Handler": "basic-handler.hello",
+      "MemorySize": 1024,
+      "Role": Object {
+        "Fn::GetAtt": Array [
+          "IamRoleLambdaExecution",
+          "Arn",
+        ],
+      },
+      "Runtime": "nodejs18.x",
+      "Timeout": 6,
+    },
+    "Type": "AWS::Lambda::Function",
+  },
+  "HelloLambdaVersioncvZrQjYr4FdYsM3CaTj5TKuOJmUjyL07tfIDVXBSw4": Object {
+    "DeletionPolicy": "Retain",
+    "Properties": Object {
+      "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0=",
+      "FunctionName": Object {
+        "Ref": "HelloLambdaFunction",
+      },
+    },
+    "Type": "AWS::Lambda::Version",
+  },
+  "HelloLogGroup": Object {
+    "Properties": Object {
+      "LogGroupName": "/aws/lambda/serverless-test-project-dev-hello",
+    },
+    "Type": "AWS::Logs::LogGroup",
+  },
+  "HttpGetterLambdaFunction": Object {
+    "DependsOn": Array [
+      "HttpGetterLogGroup",
+    ],
+    "Metadata": Object {
+      "slicWatch": Object {},
+    },
+    "Properties": Object {
+      "Code": Object {
+        "S3Bucket": Object {
+          "Ref": "ServerlessDeploymentBucket",
+        },
+        "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip",
+      },
+      "FunctionName": "serverless-test-project-dev-httpGetter",
+      "Handler": "apigw-handler.handleGet",
+      "MemorySize": 1024,
+      "Role": Object {
+        "Fn::GetAtt": Array [
+          "IamRoleLambdaExecution",
+          "Arn",
+        ],
+      },
+      "Runtime": "nodejs18.x",
+      "Timeout": 30,
+    },
+    "Type": "AWS::Lambda::Function",
+  },
+  "HttpGetterLambdaPermissionApiGateway": Object {
+    "Properties": Object {
+      "Action": "lambda:InvokeFunction",
+      "FunctionName": Object {
+        "Fn::GetAtt": Array [
+          "HttpGetterLambdaFunction",
+          "Arn",
+        ],
+      },
+      "Principal": "apigateway.amazonaws.com",
+      "SourceArn": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "arn:",
+            Object {
+              "Ref": "AWS::Partition",
+            },
+            ":execute-api:",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            ":",
+            Object {
+              "Ref": "AWS::AccountId",
+            },
+            ":",
+            Object {
+              "Ref": "ApiGatewayRestApi",
+            },
+            "/*/*",
+          ],
+        ],
+      },
+    },
+    "Type": "AWS::Lambda::Permission",
+  },
+  "HttpGetterLambdaVersionvK2ALwc1DFqBccIyulxoBU3GveALO98nQc2xP94J8": Object {
+    "DeletionPolicy": "Retain",
+    "Properties": Object {
+      "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0=",
+      "FunctionName": Object {
+        "Ref": "HttpGetterLambdaFunction",
+      },
+    },
+    "Type": "AWS::Lambda::Version",
+  },
+  "HttpGetterLogGroup": Object {
+    "Properties": Object {
+      "LogGroupName": "/aws/lambda/serverless-test-project-dev-httpGetter",
+    },
+    "Type": "AWS::Logs::LogGroup",
+  },
+  "IamRoleLambdaExecution": Object {
+    "Properties": Object {
+      "AssumeRolePolicyDocument": Object {
+        "Statement": Array [
+          Object {
+            "Action": Array [
+              "sts:AssumeRole",
+            ],
+            "Effect": "Allow",
+            "Principal": Object {
+              "Service": Array [
+                "lambda.amazonaws.com",
+              ],
+            },
+          },
+        ],
+        "Version": "2012-10-17",
+      },
+      "Path": "/",
+      "Policies": Array [
+        Object {
+          "PolicyDocument": Object {
+            "Statement": Array [
+              Object {
+                "Action": Array [
+                  "logs:CreateLogStream",
+                  "logs:CreateLogGroup",
+                  "logs:TagResource",
+                ],
+                "Effect": "Allow",
+                "Resource": Array [
+                  Object {
+                    "Fn::Sub": "arn:\${AWS::Partition}:logs:\${AWS::Region}:\${AWS::AccountId}:log-group:/aws/lambda/serverless-test-project-dev*:*",
+                  },
+                ],
+              },
+              Object {
+                "Action": Array [
+                  "logs:PutLogEvents",
+                ],
+                "Effect": "Allow",
+                "Resource": Array [
+                  Object {
+                    "Fn::Sub": "arn:\${AWS::Partition}:logs:\${AWS::Region}:\${AWS::AccountId}:log-group:/aws/lambda/serverless-test-project-dev*:*:*",
+                  },
+                ],
+              },
+              Object {
+                "Action": Array [
+                  "kinesis:GetRecords",
+                  "kinesis:GetShardIterator",
+                  "kinesis:DescribeStream",
+                  "kinesis:ListStreams",
+                ],
+                "Effect": "Allow",
+                "Resource": Array [
+                  Object {
+                    "Fn::GetAtt": Array [
+                      "stream",
+                      "Arn",
+                    ],
+                  },
+                ],
+              },
+            ],
+            "Version": "2012-10-17",
+          },
+          "PolicyName": Object {
+            "Fn::Join": Array [
+              "-",
+              Array [
+                "serverless-test-project",
+                "dev",
+                "lambda",
+              ],
+            ],
+          },
+        },
+      ],
+      "RoleName": Object {
+        "Fn::Join": Array [
+          "-",
+          Array [
+            "serverless-test-project",
+            "dev",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "lambdaRole",
+          ],
+        ],
+      },
+    },
+    "Type": "AWS::IAM::Role",
+  },
+  "PingLambdaFunction": Object {
+    "DependsOn": Array [
+      "PingLogGroup",
+    ],
+    "Metadata": Object {
+      "slicWatch": Object {
+        "dashboard": Object {
+          "enabled": false,
+        },
+      },
+    },
+    "Properties": Object {
+      "Code": Object {
+        "S3Bucket": Object {
+          "Ref": "ServerlessDeploymentBucket",
+        },
+        "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip",
+      },
+      "FunctionName": "serverless-test-project-dev-ping",
+      "Handler": "basic-handler.hello",
+      "MemorySize": 1024,
+      "Role": Object {
+        "Fn::GetAtt": Array [
+          "IamRoleLambdaExecution",
+          "Arn",
+        ],
+      },
+      "Runtime": "nodejs18.x",
+      "Timeout": 6,
+    },
+    "Type": "AWS::Lambda::Function",
+  },
+  "PingLambdaVersionSQcuddhSFqI0xKYCyuQTTJMvwrlKCB77CNQ16xyQ": Object {
+    "DeletionPolicy": "Retain",
+    "Properties": Object {
+      "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0=",
+      "FunctionName": Object {
+        "Ref": "PingLambdaFunction",
+      },
+    },
+    "Type": "AWS::Lambda::Version",
+  },
+  "PingLogGroup": Object {
+    "Properties": Object {
+      "LogGroupName": "/aws/lambda/serverless-test-project-dev-ping",
+    },
+    "Type": "AWS::Logs::LogGroup",
+  },
+  "regularQueue": Object {
+    "Properties": Object {
+      "QueueName": "SomeRegularQueue",
+    },
+    "Type": "AWS::SQS::Queue",
+  },
+  "ServerlessDeploymentBucket": Object {
+    "Properties": Object {
+      "BucketEncryption": Object {
+        "ServerSideEncryptionConfiguration": Array [
+          Object {
+            "ServerSideEncryptionByDefault": Object {
+              "SSEAlgorithm": "AES256",
+            },
+          },
+        ],
+      },
+    },
+    "Type": "AWS::S3::Bucket",
+  },
+  "ServerlessDeploymentBucketPolicy": Object {
+    "Properties": Object {
+      "Bucket": Object {
+        "Ref": "ServerlessDeploymentBucket",
+      },
+      "PolicyDocument": Object {
+        "Statement": Array [
+          Object {
+            "Action": "s3:*",
+            "Condition": Object {
+              "Bool": Object {
+                "aws:SecureTransport": false,
+              },
+            },
+            "Effect": "Deny",
+            "Principal": "*",
+            "Resource": Array [
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::",
+                    Object {
+                      "Ref": "ServerlessDeploymentBucket",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+              Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::",
+                    Object {
+                      "Ref": "ServerlessDeploymentBucket",
+                    },
+                  ],
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    },
+    "Type": "AWS::S3::BucketPolicy",
+  },
+  "ServerlesstestprojectdeveventsRulerule1EventBridgeRule": Object {
+    "Properties": Object {
+      "EventPattern": Object {
+        "detail-type": Array [
+          "Invoke Lambda Function",
+        ],
+      },
+      "Name": "serverless-test-project-dev-eventsRule-rule-1",
+      "State": "ENABLED",
+      "Targets": Array [
+        Object {
+          "Arn": Object {
+            "Fn::GetAtt": Array [
+              "EventsRuleLambdaFunction",
+              "Arn",
+            ],
+          },
+          "Id": "serverless-test-project-dev-eventsRule-rule-1-target",
+          "RetryPolicy": Object {
+            "MaximumEventAgeInSeconds": 60,
+            "MaximumRetryAttempts": 2,
+          },
+        },
+      ],
+    },
+    "Type": "AWS::Events::Rule",
+  },
+  "stream": Object {
+    "Properties": Object {
+      "Name": Object {
+        "Fn::Sub": "slic-watch-test-project-stream-\${AWS::AccountId}-\${AWS::Region}",
+      },
+      "ShardCount": 1,
+    },
+    "Type": "AWS::Kinesis::Stream",
+  },
+  "StreamProcessorEventSourceMappingKinesisStream": Object {
+    "DependsOn": Array [
+      "IamRoleLambdaExecution",
+    ],
+    "Properties": Object {
+      "BatchSize": 10,
+      "Enabled": true,
+      "EventSourceArn": Object {
+        "Fn::GetAtt": Array [
+          "stream",
+          "Arn",
+        ],
+      },
+      "FunctionName": Object {
+        "Fn::GetAtt": Array [
+          "StreamProcessorLambdaFunction",
+          "Arn",
+        ],
+      },
+      "MaximumRetryAttempts": 0,
+      "StartingPosition": "LATEST",
+    },
+    "Type": "AWS::Lambda::EventSourceMapping",
+  },
+  "StreamProcessorLambdaFunction": Object {
+    "DependsOn": Array [
+      "StreamProcessorLogGroup",
+    ],
+    "Metadata": Object {
+      "slicWatch": Object {},
+    },
+    "Properties": Object {
+      "Code": Object {
+        "S3Bucket": Object {
+          "Ref": "ServerlessDeploymentBucket",
+        },
+        "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip",
+      },
+      "FunctionName": "serverless-test-project-dev-streamProcessor",
+      "Handler": "stream-handler.handle",
+      "MemorySize": 1024,
+      "Role": Object {
+        "Fn::GetAtt": Array [
+          "IamRoleLambdaExecution",
+          "Arn",
+        ],
+      },
+      "Runtime": "nodejs18.x",
+      "Timeout": 6,
+    },
+    "Type": "AWS::Lambda::Function",
+  },
+  "StreamProcessorLambdaVersion24Kwch4oq5ogXKcIDJuLGB1qAJWt8aqgW43aCjKI": Object {
+    "DeletionPolicy": "Retain",
+    "Properties": Object {
+      "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0=",
+      "FunctionName": Object {
+        "Ref": "StreamProcessorLambdaFunction",
+      },
+    },
+    "Type": "AWS::Lambda::Version",
+  },
+  "StreamProcessorLogGroup": Object {
+    "Properties": Object {
+      "LogGroupName": "/aws/lambda/serverless-test-project-dev-streamProcessor",
+    },
+    "Type": "AWS::Logs::LogGroup",
+  },
+  "subnet": Object {
+    "Properties": Object {
+      "AvailabilityZone": "eu-west-1a",
+      "CidrBlock": "10.0.16.0/20",
+      "VpcId": Object {
+        "Ref": "vpc",
+      },
+    },
+    "Type": "AWS::EC2::Subnet",
+  },
+  "SubscriptionHandlerLambdaFunction": Object {
+    "DependsOn": Array [
+      "SubscriptionHandlerLogGroup",
+    ],
+    "Metadata": Object {
+      "slicWatch": Object {},
+    },
+    "Properties": Object {
+      "Code": Object {
+        "S3Bucket": Object {
+          "Ref": "ServerlessDeploymentBucket",
+        },
+        "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip",
+      },
+      "FunctionName": "serverless-test-project-dev-subscriptionHandler",
+      "Handler": "apigw-handler.handleSubscription",
+      "MemorySize": 1024,
+      "Role": Object {
+        "Fn::GetAtt": Array [
+          "IamRoleLambdaExecution",
+          "Arn",
+        ],
+      },
+      "Runtime": "nodejs18.x",
+      "Timeout": 30,
+    },
+    "Type": "AWS::Lambda::Function",
+  },
+  "SubscriptionHandlerLambdaPermissionApiGateway": Object {
+    "Properties": Object {
+      "Action": "lambda:InvokeFunction",
+      "FunctionName": Object {
+        "Fn::GetAtt": Array [
+          "SubscriptionHandlerLambdaFunction",
+          "Arn",
+        ],
+      },
+      "Principal": "apigateway.amazonaws.com",
+      "SourceArn": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "arn:",
+            Object {
+              "Ref": "AWS::Partition",
+            },
+            ":execute-api:",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            ":",
+            Object {
+              "Ref": "AWS::AccountId",
+            },
+            ":",
+            Object {
+              "Ref": "ApiGatewayRestApi",
+            },
+            "/*/*",
+          ],
+        ],
+      },
+    },
+    "Type": "AWS::Lambda::Permission",
+  },
+  "SubscriptionHandlerLambdaVersion4kKEYaIgWsMN0XYzRQn4VAailfQcZ23kdSSOKepfB4A": Object {
+    "DeletionPolicy": "Retain",
+    "Properties": Object {
+      "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0=",
+      "FunctionName": Object {
+        "Ref": "SubscriptionHandlerLambdaFunction",
+      },
+    },
+    "Type": "AWS::Lambda::Version",
+  },
+  "SubscriptionHandlerLogGroup": Object {
+    "Properties": Object {
+      "LogGroupName": "/aws/lambda/serverless-test-project-dev-subscriptionHandler",
+    },
+    "Type": "AWS::Logs::LogGroup",
+  },
+  "subscriptionTest": Object {
+    "Properties": Object {
+      "Endpoint": Object {
+        "Fn::Sub": "https://\${ApiGatewayRestApi}.execute-api.\${AWS::Region}.amazonaws.com/dev/subscription",
+      },
+      "Protocol": "https",
+      "TopicArn": Object {
+        "Ref": "topic",
+      },
+    },
+    "Type": "AWS::SNS::Subscription",
+  },
+  "taskDef": Object {
+    "Properties": Object {
+      "ContainerDefinitions": Array [
+        Object {
+          "Command": Array [
+            "/bin/sh -c \\"while true; do echo Hello; sleep 10; done\\"",
+          ],
+          "Cpu": 256,
+          "EntryPoint": Array [
+            "sh",
+            "-c",
+          ],
+          "Essential": true,
+          "Image": "busybox",
+          "Memory": 512,
+          "Name": "busybox",
+        },
+      ],
+      "Cpu": 256,
+      "Memory": 512,
+      "NetworkMode": "awsvpc",
+      "RequiresCompatibilities": Array [
+        "FARGATE",
+      ],
+    },
+    "Type": "AWS::ECS::TaskDefinition",
+  },
+  "ThrottlerLambdaFunction": Object {
+    "DependsOn": Array [
+      "ThrottlerLogGroup",
+    ],
+    "Metadata": Object {
+      "slicWatch": Object {},
+    },
+    "Properties": Object {
+      "Code": Object {
+        "S3Bucket": Object {
+          "Ref": "ServerlessDeploymentBucket",
+        },
+        "S3Key": "serverless/serverless-test-project/dev/1701242216679-2023-11-29T07:16:56.679Z/serverless-test-project.zip",
+      },
+      "FunctionName": "serverless-test-project-dev-throttler",
+      "Handler": "basic-handler.hello",
+      "MemorySize": 1024,
+      "ReservedConcurrentExecutions": 0,
+      "Role": Object {
+        "Fn::GetAtt": Array [
+          "IamRoleLambdaExecution",
+          "Arn",
+        ],
+      },
+      "Runtime": "nodejs18.x",
+      "Timeout": 6,
+    },
+    "Type": "AWS::Lambda::Function",
+  },
+  "ThrottlerLambdaVersion0UeWLgxZYywcyV3gGiutpyCQJEbO6Gk8zSSOP7dMEps": Object {
+    "DeletionPolicy": "Retain",
+    "Properties": Object {
+      "CodeSha256": "8+6CAXAhHnCOtQPN1A6d4fRjjFV13css2+2nirSNse0=",
+      "FunctionName": Object {
+        "Ref": "ThrottlerLambdaFunction",
+      },
+    },
+    "Type": "AWS::Lambda::Version",
+  },
+  "ThrottlerLogGroup": Object {
+    "Properties": Object {
+      "LogGroupName": "/aws/lambda/serverless-test-project-dev-throttler",
+    },
+    "Type": "AWS::Logs::LogGroup",
+  },
+  "topic": Object {
+    "Properties": Object {
+      "TopicName": Object {
+        "Fn::Sub": "slic-watch-test-project-topic-\${AWS::AccountId}-\${AWS::Region}",
+      },
+    },
+    "Type": "AWS::SNS::Topic",
+  },
+  "vpc": Object {
+    "Properties": Object {
+      "CidrBlock": "10.0.0.0/16",
+    },
+    "Type": "AWS::EC2::VPC",
+  },
+  "Workflow": Object {
+    "DependsOn": Array [
+      "WorkflowRole",
+    ],
+    "Properties": Object {
+      "DefinitionString": Object {
+        "Fn::Sub": Array [
+          String(
+            {
+              "StartAt": "What Next?",
+              "States": {
+                "What Next?": {
+                  "Type": "Choice",
+                  "Choices": [
+                    {
+                      "Variable": "$.destination",
+                      "StringEquals": "fail",
+                      "Next": "Fail"
+                    },
+                    {
+                      "Variable": "$.destination",
+                      "StringEquals": "timeoutTask",
+                      "Next": "TimeoutTask"
+                    },
+                    {
+                      "Variable": "$.destination",
+                      "StringEquals": "keepWaiting",
+                      "Next": "KeepWaiting"
+                    }
+                  ],
+                  "Default": "Succeed"
+                },
+                "TimeoutTask": {
+                  "Type": "Task",
+                  "TimeoutSeconds": 1,
+                  "Resource": "\${085edd942ce144c5bd80364a6e973e4d}",
+                  "Parameters": {
+                    "sleepSeconds": 3
+                  },
+                  "Next": "Succeed"
+                },
+                "KeepWaiting": {
+                  "Type": "Wait",
+                  "Seconds": 1,
+                  "Next": "KeepWaiting"
+                },
+                "Fail": {
+                  "Type": "Fail"
+                },
+                "Succeed": {
+                  "Type": "Pass",
+                  "End": true
+                }
+              }
+            }
+          ),
+          Object {
+            "085edd942ce144c5bd80364a6e973e4d": Object {
+              "Fn::GetAtt": Array [
+                "PingLambdaFunction",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "LoggingConfiguration": Object {
+        "Destinations": Array [
+          Object {
+            "CloudWatchLogsLogGroup": Object {
+              "LogGroupArn": Object {
+                "Fn::GetAtt": Array [
+                  "workflowLogGroup",
+                  "Arn",
+                ],
+              },
+            },
+          },
+        ],
+        "IncludeExecutionData": true,
+        "Level": "ALL",
+      },
+      "RoleArn": Object {
+        "Fn::GetAtt": Array [
+          "WorkflowRole",
+          "Arn",
+        ],
+      },
+      "StateMachineName": "Workflow",
+    },
+    "Type": "AWS::StepFunctions::StateMachine",
+  },
+  "workflowLogGroup": Object {
+    "Properties": Object {
+      "LogGroupName": "WorkflowLogs",
+      "RetentionInDays": 1,
+    },
+    "Type": "AWS::Logs::LogGroup",
+  },
+  "WorkflowRole": Object {
+    "Properties": Object {
+      "AssumeRolePolicyDocument": Object {
+        "Statement": Array [
+          Object {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": Object {
+              "Service": Object {
+                "Fn::Sub": "states.\${AWS::Region}.amazonaws.com",
+              },
+            },
+          },
+        ],
+        "Version": "2012-10-17",
+      },
+      "Policies": Array [
+        Object {
+          "PolicyDocument": Object {
+            "Statement": Array [
+              Object {
+                "Action": Array [
+                  "lambda:InvokeFunction",
+                ],
+                "Effect": "Allow",
+                "Resource": Array [
+                  Object {
+                    "Fn::GetAtt": Array [
+                      "PingLambdaFunction",
+                      "Arn",
+                    ],
+                  },
+                  Object {
+                    "Fn::Sub": Array [
+                      "\${functionArn}:*",
+                      Object {
+                        "functionArn": Object {
+                          "Fn::GetAtt": Array [
+                            "PingLambdaFunction",
+                            "Arn",
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+              Object {
+                "Action": Array [
+                  "logs:CreateLogDelivery",
+                  "logs:GetLogDelivery",
+                  "logs:UpdateLogDelivery",
+                  "logs:DeleteLogDelivery",
+                  "logs:ListLogDeliveries",
+                  "logs:PutResourcePolicy",
+                  "logs:DescribeResourcePolicies",
+                  "logs:DescribeLogGroups",
+                ],
+                "Effect": "Allow",
+                "Resource": "*",
+              },
+            ],
+            "Version": "2012-10-17",
+          },
+          "PolicyName": "dev-serverless-test-project-statemachine",
+        },
+      ],
+    },
+    "Type": "AWS::IAM::Role",
+  },
+}
+`

--- a/test-utils/package.json
+++ b/test-utils/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "test-utils",
+    "description": "Common test utilities",
+    "version": "3.1.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/fourTheorem/slic-watch.git",
+        "directory": "test-utils"
+    },
+    "license": "Apache",
+    "dependencies": {},
+    "scripts": {
+        "test": "echo"
+    }
+}

--- a/test-utils/sls-test-utils.ts
+++ b/test-utils/sls-test-utils.ts
@@ -1,0 +1,59 @@
+import { type Template } from 'cloudform'
+import pino from 'pino'
+
+// Serverless Framework provides plugins with a logger to use, so we simulate that with this:
+export const dummyLogger = Object.assign({}, pino())
+const extras = ['levels', 'silent', 'onChild', 'trace', 'debug', 'info', 'warn', 'error', 'fatal']
+for (const extra of extras) {
+  // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+  delete dummyLogger[extra]
+}
+export const pluginUtils = { log: dummyLogger }
+
+export interface SlsYaml {
+  custom?
+  functions?
+}
+
+export const slsYaml: SlsYaml = {
+  custom: {
+    slicWatch: {
+      topicArn: 'test-topic',
+      enabled: true
+    }
+  },
+  functions: {
+    hello: {
+    }
+  }
+}
+
+export function createMockServerless (compiledTemplate: Template) {
+  return {
+    cli: {
+      log: () => { '' }
+    },
+    providers: { aws: {} },
+    getProvider: () => ({
+      naming: {
+        getLambdaLogicalId: (funcName: string) => {
+          return funcName[0].toUpperCase() + funcName.slice(1) + 'LambdaFunction'
+        }
+      }
+    }),
+    service: {
+      provider: {
+        name: 'aws',
+        compiledCloudFormationTemplate: compiledTemplate
+      },
+      custom: {
+        slicWatch: {
+          enabled: true,
+          topicArn: 'test-topic'
+        }
+      },
+      getAllFunctions: () => Object.keys(slsYaml.functions),
+      getFunction: (funcRef) => slsYaml.functions[funcRef]
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "esm": true,
   "compilerOptions": {
+    "allowJs": true,
     "module": "commonjs",
     "strict": true,
     "noImplicitAny": false,
@@ -29,6 +30,12 @@
   "include": [
     "core",
     "serverless-plugin",
-    "cf-macro"
+    "cf-macro",
+    "serverless-test-project/tests",
+    "serverless-test-project-alb/tests",
+    "serverless-test-project-appsync/tests",
+    "sam-test-project/tests",
+    "cdk-test-project",
+    "test-utils"
   ]
 }


### PR DESCRIPTION
Add snapshot tests for all test projects 

## Description>
- Added snapshot tests for serverless-test-project-*, cdk-test-project, sam-test-project

## Motivation and Context
- Unit test coverage is better now but regressions can be missed
- Allows us to detect valid and invalid deviations in generate templates, logical IDs, etc.

## How Has This Been Tested?
- Self-tested only

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
