### PR TITLE
fix(core): esbuild with cjs, fixes #115

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -12,7 +12,7 @@
     "test:packages": "tap --no-check-coverage --no-coverage-report --test-regex='tests\\/.*(test.ts)'",
     "test:coverage": "tap --check-coverage --coverage-report=html --no-browser --branches=95 --lines=99 --statements=99 --functions=99",
     "test": "npm run test:packages && npm run test:coverage",
-    "build": "esbuild **/*.ts index.ts --outdir=dist/ --platform=node --format=esm --packages=external --bundle --sourcemap"
+    "build": "esbuild **/*.ts index.ts --outdir=dist/ --platform=node --format=cjs --packages=external --bundle --sourcemap"
   },
   "tap": {
     "node-arg": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The previous output of core was esm, but as the file is .js and no type module or exports are present in package.json both require and import fail.

Changing the format to cjs fixes the issue, the size of dist isn't any larger. That said if we're using esbuild with sourcemaps we could minify to get a much smaller payload?

I chose cjs instead of esm + type module because the esm output from esbuild didn't work with lodash.

## Motivation and Context

Fixes #115.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Yes.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
