### PR TITLE
fix: trying to read `Metadata` of undefined

### DIFF
--- a/serverless-plugin/serverless-plugin.ts
+++ b/serverless-plugin/serverless-plugin.ts
@@ -71,9 +71,11 @@ class ServerlessPlugin {
         const funcConfig = func.slicWatch ?? {}
         const functionLogicalId = awsProvider.naming.getLambdaLogicalId(funcName)
         const templateResources = compiledTemplate.Resources as Record<string, Resource>
-        templateResources[functionLogicalId].Metadata = {
-          ...templateResources[functionLogicalId].Metadata ?? {},
-          slicWatch: funcConfig
+        if (typeof templateResources[functionLogicalId] !== 'undefined') {
+          templateResources[functionLogicalId].Metadata = {
+            ...templateResources[functionLogicalId].Metadata ?? {},
+            slicWatch: funcConfig
+          }
         }
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes #117 
The resource map may not have a given logical ID, this results into a runtime error for such cases.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Could not deploy slic-watch
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Could deploy after fix
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
